### PR TITLE
Fix Docker environment variable passing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ CMD ["react-scripts", "start"]
 FROM appbase as staticbuilder
 # ===================================
 
+ARG REACT_APP_API_URI
+ARG REACT_APP_OIDC_AUTHORITY
+
 COPY . /app
 RUN yarn build
 


### PR DESCRIPTION
Previously the build time environment variables from the GitLab
pipeline config didn't reach the container properly.