### PR TITLE
KK-230 | Add initial occurrence details page

### DIFF
--- a/src/api/dataProvider.ts
+++ b/src/api/dataProvider.ts
@@ -19,6 +19,7 @@ import {
 import {
   addOccurrence,
   getOccurrences,
+  getOccurrence,
 } from '../domain/occurrences/api/OccurrenceApi';
 import { getChild, getChildren } from '../domain/children/api/ChildApi';
 
@@ -38,12 +39,15 @@ const METHOD_HANDLERS: MethodHandlers = {
     UPDATE: updateEvent,
   },
   occurrences: {
+    LIST: getEvents,
+    ONE: getOccurrence,
     CREATE: addOccurrence,
     MANY_REFERENCE: getOccurrences,
   },
   children: {
     LIST: getChildren,
     ONE: getChild,
+    MANY_REFERENCE: getChildren,
   },
 };
 

--- a/src/api/generatedTypes/Occurrence.ts
+++ b/src/api/generatedTypes/Occurrence.ts
@@ -1,0 +1,105 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { Language } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: Occurrence
+// ====================================================
+
+export interface Occurrence_occurrence_event {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  capacityPerOccurrence: number;
+  /**
+   * In minutes
+   */
+  duration: number | null;
+}
+
+export interface Occurrence_occurrence_venue_translations {
+  languageCode: Language;
+  name: string;
+}
+
+export interface Occurrence_occurrence_venue {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  translations: Occurrence_occurrence_venue_translations[];
+}
+
+export interface Occurrence_occurrence_children_edges_node_guardians_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  email: string | null;
+}
+
+export interface Occurrence_occurrence_children_edges_node_guardians_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: Occurrence_occurrence_children_edges_node_guardians_edges_node | null;
+}
+
+export interface Occurrence_occurrence_children_edges_node_guardians {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (Occurrence_occurrence_children_edges_node_guardians_edges | null)[];
+}
+
+export interface Occurrence_occurrence_children_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  firstName: string;
+  lastName: string;
+  birthdate: any;
+  guardians: Occurrence_occurrence_children_edges_node_guardians;
+}
+
+export interface Occurrence_occurrence_children_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: Occurrence_occurrence_children_edges_node | null;
+}
+
+export interface Occurrence_occurrence_children {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (Occurrence_occurrence_children_edges | null)[];
+}
+
+export interface Occurrence_occurrence {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  time: any;
+  event: Occurrence_occurrence_event;
+  enrolmentCount: number;
+  venue: Occurrence_occurrence_venue;
+  children: Occurrence_occurrence_children;
+}
+
+export interface Occurrence {
+  /**
+   * The ID of the object
+   */
+  occurrence: Occurrence_occurrence | null;
+}
+
+export interface OccurrenceVariables {
+  id: string;
+}

--- a/src/api/generatedTypes/Occurrences.ts
+++ b/src/api/generatedTypes/Occurrences.ts
@@ -34,6 +34,53 @@ export interface Occurrences_occurrences_edges_node_venue {
   translations: Occurrences_occurrences_edges_node_venue_translations[];
 }
 
+export interface Occurrences_occurrences_edges_node_children_edges_node_guardians_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  email: string | null;
+}
+
+export interface Occurrences_occurrences_edges_node_children_edges_node_guardians_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: Occurrences_occurrences_edges_node_children_edges_node_guardians_edges_node | null;
+}
+
+export interface Occurrences_occurrences_edges_node_children_edges_node_guardians {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (Occurrences_occurrences_edges_node_children_edges_node_guardians_edges | null)[];
+}
+
+export interface Occurrences_occurrences_edges_node_children_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  firstName: string;
+  lastName: string;
+  birthdate: any;
+  guardians: Occurrences_occurrences_edges_node_children_edges_node_guardians;
+}
+
+export interface Occurrences_occurrences_edges_node_children_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: Occurrences_occurrences_edges_node_children_edges_node | null;
+}
+
+export interface Occurrences_occurrences_edges_node_children {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (Occurrences_occurrences_edges_node_children_edges | null)[];
+}
+
 export interface Occurrences_occurrences_edges_node {
   /**
    * The ID of the object.
@@ -43,6 +90,7 @@ export interface Occurrences_occurrences_edges_node {
   event: Occurrences_occurrences_edges_node_event;
   enrolmentCount: number;
   venue: Occurrences_occurrences_edges_node_venue;
+  children: Occurrences_occurrences_edges_node_children;
 }
 
 export interface Occurrences_occurrences_edges {

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -95,6 +95,9 @@
     "create": {
       "title": "Add occurrence"
     },
+    "show": {
+      "title": "Occurrence"
+    },
     "fields": {
       "time": {
         "label": "Time",
@@ -107,7 +110,7 @@
           }
         }
       },
-      "venues": {
+      "venue": {
         "label": "Venue"
       },
       "event": {
@@ -118,6 +121,9 @@
       },
       "enrolmentsCount": {
         "label": "Number of enrolments"
+      },
+      "children": {
+        "label": "Enrolled children"
       }
     },
     "addOccurrenceButton": {

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -95,6 +95,9 @@
     "create": {
       "title": "Lisää ajankohta"
     },
+    "show": {
+      "title": "Tapahtuma-ajankohta"
+    },
     "fields": {
       "time": {
         "label": "Aika",
@@ -107,7 +110,7 @@
           }
         }
       },
-      "venues": {
+      "venue": {
         "label": "Tapahtumapaikka"
       },
       "event": {
@@ -118,6 +121,9 @@
       },
       "enrolmentsCount": {
         "label": "Osallistujia"
+      },
+      "children": {
+        "label": "Osallistujat"
       }
     },
     "addOccurrenceButton": {

--- a/src/common/translation/sv.json
+++ b/src/common/translation/sv.json
@@ -95,6 +95,9 @@
     "create": {
       "title": "Add occurrence"
     },
+    "show": {
+      "title": "Occurrence"
+    },
     "fields": {
       "time": {
         "label": "Time",
@@ -107,7 +110,7 @@
           }
         }
       },
-      "venues": {
+      "venue": {
         "label": "Venue"
       },
       "event": {
@@ -118,6 +121,9 @@
       },
       "enrolmentsCount": {
         "label": "Number of enrolments"
+      },
+      "children": {
+        "label": "Enrolled children"
       }
     },
     "addOccurrenceButton": {

--- a/src/domain/application/App.tsx
+++ b/src/domain/application/App.tsx
@@ -23,6 +23,7 @@ import EventCreate from '../events/create/EventCreate';
 import EventEdit from '../events/edit/EventEdit';
 import OccurrenceCreate from '../occurrences/OccurrenceCreate';
 import ChildList from '../children/ChildList';
+import OccurrenceShow from '../occurrences/OccurrenceShow';
 import ChildShow from '../children/ChildShow';
 
 const history = createHistory();
@@ -65,7 +66,11 @@ const App: React.FC = () => {
         create={EventCreate}
         edit={EventEdit}
       />
-      <Resource name="occurrences" create={OccurrenceCreate} />
+      <Resource
+        name="occurrences"
+        create={OccurrenceCreate}
+        show={OccurrenceShow}
+      />
     </Admin>
   );
 };

--- a/src/domain/children/ChildShow.tsx
+++ b/src/domain/children/ChildShow.tsx
@@ -14,8 +14,17 @@ import {
 } from 'react-admin';
 
 import { languageChoices } from '../../common/choices';
-import { Child_child as Child } from '../../api/generatedTypes/Child';
+import {
+  Child_child as Child,
+  Child_child_occurrences_edges as OccurrenceEdges,
+} from '../../api/generatedTypes/Child';
 import { OccurrenceTimeRangeField } from '../occurrences/fields';
+
+interface RowClickParams<T> {
+  id: string;
+  basePath: string;
+  record: T;
+}
 
 const ChildShow = (props: any) => {
   const locale = useLocale();
@@ -61,7 +70,11 @@ const ChildShow = (props: any) => {
           source="occurrences.edges"
           label="children.fields.occurrences.label"
         >
-          <Datagrid>
+          <Datagrid
+            rowClick={(id: string, basePath: string, record: OccurrenceEdges) =>
+              `/occurrences/${encodeURIComponent(record.node?.id || '')}/show`
+            }
+          >
             <DateField
               label="occurrences.fields.time.fields.date.label"
               source="node.time"
@@ -80,7 +93,7 @@ const ChildShow = (props: any) => {
               <TextField source="translations.FI.name" />
             </ReferenceField>
             <ReferenceField
-              label="occurrences.fields.venues.label"
+              label="occurrences.fields.venue.label"
               source="node.venue.id"
               reference="venues"
               link="show"

--- a/src/domain/children/api/ChildApi.ts
+++ b/src/domain/children/api/ChildApi.ts
@@ -12,6 +12,7 @@ import { Child as ApiChild } from '../../../api/generatedTypes/Child';
 const getChildren: MethodHandler = async (params: MethodHandlerParams) => {
   const response: ApolloQueryResult<Children> = await queryHandler({
     query: childrenQuery,
+    variables: { occurrenceId: params.id },
   });
   return response.data.children?.edges.map(edge =>
     edge?.node ? mapApiDataToLocalData(edge.node) : null

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -95,7 +95,7 @@ const EventShow: FunctionComponent = (props: any) => {
             reference="occurrences"
             target="event_id"
           >
-            <Datagrid>
+            <Datagrid rowClick="show">
               <DateField
                 label="occurrences.fields.time.fields.date.label"
                 source="time"
@@ -106,9 +106,10 @@ const EventShow: FunctionComponent = (props: any) => {
                 locales={locale}
               />
               <ReferenceField
-                label="occurrences.fields.venues.label"
+                label="occurrences.fields.venue.label"
                 source="venue.id"
                 reference="venues"
+                link="show"
               >
                 <TextField source="translations.FI.name" />
               </ReferenceField>

--- a/src/domain/occurrences/OccurrenceCreate.tsx
+++ b/src/domain/occurrences/OccurrenceCreate.tsx
@@ -22,7 +22,7 @@ const OccurrenceCreate = (props: any) => {
           validate={[required()]}
         />
         <ReferenceInput
-          label="occurrences.fields.venues.label"
+          label="occurrences.fields.venue.label"
           source="venueId"
           reference="venues"
         >

--- a/src/domain/occurrences/OccurrenceShow.tsx
+++ b/src/domain/occurrences/OccurrenceShow.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  Show,
+  TextField,
+  NumberField,
+  DateField,
+  Datagrid,
+  ReferenceField,
+  useLocale,
+  SimpleShowLayout,
+  EmailField,
+  ArrayField,
+  FunctionField,
+} from 'react-admin';
+
+import { Children_children_edges as ChildEdge } from '../../api/generatedTypes/Children';
+import { OccurrenceTimeRangeField } from './fields';
+
+const OccurrenceShow = (props: any) => {
+  const locale = useLocale();
+
+  return (
+    <Show {...props} title="occurrences.show.title">
+      <SimpleShowLayout>
+        <ReferenceField
+          label="occurrences.fields.event.label"
+          source="event.id"
+          reference="events"
+          link="show"
+        >
+          <TextField source="translations.FI.name" />
+        </ReferenceField>
+        <DateField
+          label="occurrences.fields.time.fields.date.label"
+          source="time"
+          locales={locale}
+        />
+        <OccurrenceTimeRangeField locales={locale} />
+        <ReferenceField
+          label="occurrences.fields.venue.label"
+          source="venue.id"
+          reference="venues"
+          link="show"
+        >
+          <TextField source="translations.FI.name" />
+        </ReferenceField>
+        <NumberField
+          source="event.capacityPerOccurrence"
+          label="occurrences.fields.capacity.label"
+        />
+        <ArrayField
+          label="occurrences.fields.children.label"
+          source="children.edges"
+        >
+          <Datagrid
+            rowClick={(id: any, basePath: any, record: any) =>
+              escape(`/children/${record.node.id}/show`)
+            }
+          >
+            <FunctionField
+              label="children.fields.name.label"
+              render={(record: ChildEdge) =>
+                `${record.node?.firstName} ${record.node?.lastName}`.trim()
+              }
+            />
+            <DateField
+              source="node.birthdate"
+              label="children.fields.birthdate.label"
+              locales={locale}
+            />
+            <EmailField
+              source="node.guardians.edges.0.node.email"
+              label="children.fields.guardians.label"
+            />
+          </Datagrid>
+        </ArrayField>
+      </SimpleShowLayout>
+    </Show>
+  );
+};
+
+export default OccurrenceShow;

--- a/src/domain/occurrences/api/OccurrenceApi.ts
+++ b/src/domain/occurrences/api/OccurrenceApi.ts
@@ -7,8 +7,12 @@ import {
   mapLocalDataToApiData,
   mutationHandler,
 } from '../../../api/utils/apiUtils';
-import { occurrencesQuery } from '../queries/OccurrenceQueries';
+import {
+  occurrencesQuery,
+  occurrenceQuery,
+} from '../queries/OccurrenceQueries';
 import { Occurrences as ApiOccurrences } from '../../../api/generatedTypes/Occurrences';
+import { Occurrence_occurrence as ApiOccurrence } from '../../../api/generatedTypes/Occurrence';
 import { addOccurrenceMutation } from '../mutations/OccurrenceMutations';
 
 const getOccurrences: MethodHandler = async (params: MethodHandlerParams) => {
@@ -16,9 +20,19 @@ const getOccurrences: MethodHandler = async (params: MethodHandlerParams) => {
     query: occurrencesQuery,
     variables: { eventId: params.id },
   });
-  return response.data.occurrences?.edges.map(edge =>
+  const data = response.data.occurrences?.edges.map(edge =>
     edge?.node ? mapApiDataToLocalData(edge.node) : null
   );
+  return data;
+};
+
+const getOccurrence: MethodHandler = async (params: MethodHandlerParams) => {
+  const response: ApolloQueryResult<ApiOccurrence> = await queryHandler({
+    query: occurrenceQuery,
+    variables: { id: params.id },
+  });
+  const data = response.data ? mapApiDataToLocalData(response.data) : null;
+  return data;
 };
 
 const addOccurrence: MethodHandler = async (params: MethodHandlerParams) => {
@@ -32,4 +46,4 @@ const addOccurrence: MethodHandler = async (params: MethodHandlerParams) => {
     : null;
 };
 
-export { getOccurrences, addOccurrence };
+export { getOccurrences, getOccurrence, addOccurrence };

--- a/src/domain/occurrences/queries/OccurrenceQueries.ts
+++ b/src/domain/occurrences/queries/OccurrenceQueries.ts
@@ -20,6 +20,64 @@ export const occurrencesQuery = gql`
               name
             }
           }
+          children {
+            edges {
+              node {
+                id
+                firstName
+                lastName
+                birthdate
+                guardians {
+                  edges {
+                    node {
+                      id
+                      email
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const occurrenceQuery = gql`
+  query Occurrence($id: ID!) {
+    occurrence(id: $id) {
+      id
+      time
+      event {
+        id
+        capacityPerOccurrence
+        duration
+      }
+      enrolmentCount
+      venue {
+        id
+        translations {
+          languageCode
+          name
+        }
+      }
+      children {
+        edges {
+          node {
+            id
+            firstName
+            lastName
+            birthdate
+            guardians {
+              edges {
+                node {
+                  id
+                  email
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
![Screenshot 2020-04-30 at 10 24 14](https://user-images.githubusercontent.com/1314604/80683515-fc5aec00-8acc-11ea-9bf8-3b969a59b340.png)

Known issue: for some reason occurrence details page urls don't work,
so refreshing the app while viewing occurrence details will result in
a blank page. Also, perhaps for the same reason, clicking an occurrence
in child details page's occurrence list will result in the same blank
page.