### PR TITLE
KK-349 & KK-439 | Implement event and venue delete

### DIFF
--- a/src/api/dataProvider.ts
+++ b/src/api/dataProvider.ts
@@ -3,6 +3,7 @@ import {
   getVenue,
   addVenue,
   updateVenue,
+  deleteVenue,
 } from '../domain/venues/api/VenueApi';
 import {
   MethodHandlers,
@@ -33,6 +34,7 @@ const METHOD_HANDLERS: MethodHandlers = {
     MANY: getVenues,
     CREATE: addVenue,
     UPDATE: updateVenue,
+    DELETE: deleteVenue,
   },
   events: {
     LIST: getEvents,
@@ -110,6 +112,10 @@ const dataProvider = {
   },
   update: async (resource: Resource, params: Params) => {
     const data = await runHandler('UPDATE', resource, params);
+    return { data };
+  },
+  delete: async (resource: Resource, params: Params) => {
+    const data = await runHandler('DELETE', resource, params);
     return { data };
   },
   publish: async (resource: Resource, params: Params) => {

--- a/src/api/dataProvider.ts
+++ b/src/api/dataProvider.ts
@@ -17,6 +17,7 @@ import {
   addEvent,
   updateEvent,
   publishEvent,
+  deleteEvent,
 } from '../domain/events/api/EventApi';
 import {
   addOccurrence,
@@ -42,6 +43,7 @@ const METHOD_HANDLERS: MethodHandlers = {
     MANY: getEvents,
     CREATE: addEvent,
     UPDATE: updateEvent,
+    DELETE: deleteEvent,
     PUBLISH: publishEvent,
   },
   occurrences: {

--- a/src/api/generatedTypes/Venue.ts
+++ b/src/api/generatedTypes/Venue.ts
@@ -19,12 +19,27 @@ export interface Venue_venue_translations {
   additionalInfo: string;
 }
 
+export interface Venue_venue_occurrences_pageInfo {
+  /**
+   * When paginating backwards, the cursor to continue.
+   */
+  startCursor: string | null;
+}
+
+export interface Venue_venue_occurrences {
+  /**
+   * Pagination data for this connection.
+   */
+  pageInfo: Venue_venue_occurrences_pageInfo;
+}
+
 export interface Venue_venue {
   /**
    * The ID of the object.
    */
   id: string;
   translations: Venue_venue_translations[];
+  occurrences: Venue_venue_occurrences;
 }
 
 export interface Venue {

--- a/src/api/generatedTypes/Venues.ts
+++ b/src/api/generatedTypes/Venues.ts
@@ -15,12 +15,27 @@ export interface Venues_venues_edges_node_translations {
   languageCode: Language;
 }
 
+export interface Venues_venues_edges_node_occurrences_pageInfo {
+  /**
+   * When paginating backwards, the cursor to continue.
+   */
+  startCursor: string | null;
+}
+
+export interface Venues_venues_edges_node_occurrences {
+  /**
+   * Pagination data for this connection.
+   */
+  pageInfo: Venues_venues_edges_node_occurrences_pageInfo;
+}
+
 export interface Venues_venues_edges_node {
   /**
    * The ID of the object.
    */
   id: string;
   translations: Venues_venues_edges_node_translations[];
+  occurrences: Venues_venues_edges_node_occurrences;
 }
 
 export interface Venues_venues_edges {

--- a/src/api/generatedTypes/deleteEvent.ts
+++ b/src/api/generatedTypes/deleteEvent.ts
@@ -1,0 +1,22 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { DeleteEventMutationInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: deleteEvent
+// ====================================================
+
+export interface deleteEvent_deleteEvent {
+  clientMutationId: string | null;
+}
+
+export interface deleteEvent {
+  deleteEvent: deleteEvent_deleteEvent | null;
+}
+
+export interface deleteEventVariables {
+  input: DeleteEventMutationInput;
+}

--- a/src/api/generatedTypes/deleteVenue.ts
+++ b/src/api/generatedTypes/deleteVenue.ts
@@ -1,0 +1,22 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { DeleteVenueMutationInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: deleteVenue
+// ====================================================
+
+export interface deleteVenue_deleteVenue {
+  clientMutationId: string | null;
+}
+
+export interface deleteVenue {
+  deleteVenue: deleteVenue_deleteVenue | null;
+}
+
+export interface deleteVenueVariables {
+  input: DeleteVenueMutationInput;
+}

--- a/src/api/generatedTypes/globalTypes.ts
+++ b/src/api/generatedTypes/globalTypes.ts
@@ -45,6 +45,11 @@ export interface AddVenueMutationInput {
   clientMutationId?: string | null;
 }
 
+export interface DeleteEventMutationInput {
+  id: string;
+  clientMutationId?: string | null;
+}
+
 export interface DeleteVenueMutationInput {
   id: string;
   clientMutationId?: string | null;

--- a/src/api/generatedTypes/globalTypes.ts
+++ b/src/api/generatedTypes/globalTypes.ts
@@ -45,6 +45,11 @@ export interface AddVenueMutationInput {
   clientMutationId?: string | null;
 }
 
+export interface DeleteVenueMutationInput {
+  id: string;
+  clientMutationId?: string | null;
+}
+
 export interface EventTranslationsInput {
   name?: string | null;
   shortDescription?: string | null;

--- a/src/domain/children/ChildList.tsx
+++ b/src/domain/children/ChildList.tsx
@@ -15,7 +15,7 @@ import { languageChoices } from '../../common/choices';
 const ChildList = (props: any) => {
   const locale = useLocale();
   return (
-    <List title="children.list.title" {...props}>
+    <List title="children.list.title" bulkActionButtons={false} {...props}>
       <Datagrid rowClick="show">
         <FunctionField
           label="children.fields.name.label"

--- a/src/domain/events/api/EventApi.ts
+++ b/src/domain/events/api/EventApi.ts
@@ -14,6 +14,7 @@ import {
   addEventMutation,
   publishEventMutation,
   updateEventMutation,
+  deleteEventMutation,
 } from '../mutations/EventMutations';
 import { getProjectId } from '../../profile/utils';
 
@@ -78,4 +79,19 @@ const publishEvent: MethodHandler = async (params: MethodHandlerParams) => {
     : null;
 };
 
-export { getEvents, getEvent, addEvent, updateEvent, publishEvent };
+const deleteEvent: MethodHandler = async (params: MethodHandlerParams) => {
+  await mutationHandler({
+    mutation: deleteEventMutation,
+    variables: { input: { id: params.id } },
+  });
+  return { id: params.id };
+};
+
+export {
+  getEvents,
+  getEvent,
+  addEvent,
+  updateEvent,
+  publishEvent,
+  deleteEvent,
+};

--- a/src/domain/events/edit/EventEdit.tsx
+++ b/src/domain/events/edit/EventEdit.tsx
@@ -9,6 +9,9 @@ import {
   SelectInput,
   NumberInput,
   required,
+  Toolbar,
+  SaveButton,
+  DeleteButton,
 } from 'react-admin';
 
 import LanguageTabs from '../../../common/components/languageTab/LanguageTabs';
@@ -21,6 +24,15 @@ import {
   validateShortDescription,
 } from '../validations';
 import { participantsPerInviteChoices } from '../choices';
+
+const EventEditToolbar = (props: any) => {
+  return (
+    <Toolbar style={{ justifyContent: 'space-between' }} {...props}>
+      <SaveButton />
+      <DeleteButton disabled={Boolean(props.record.occurrences.edges.length)} />
+    </Toolbar>
+  );
+};
 
 const EventEdit = (props: any) => {
   const translate = useTranslate();
@@ -47,7 +59,11 @@ const EventEdit = (props: any) => {
   // Undoable is false to prevent image from appearing while waiting for backend result.
   return (
     <Edit undoable={false} title={'events.edit.title'} {...props}>
-      <SimpleForm redirect="show" validate={validateVenue}>
+      <SimpleForm
+        redirect="show"
+        validate={validateVenue}
+        toolbar={<EventEditToolbar />}
+      >
         <LanguageTabs
           selectedLanguage={selectedLanguage}
           onSelect={selectLanguage}

--- a/src/domain/events/list/EventList.tsx
+++ b/src/domain/events/list/EventList.tsx
@@ -18,7 +18,7 @@ const EventList = (props: any) => {
   const locale = useLocale();
 
   return (
-    <List title={translate('events.list.title')} {...props}>
+    <List title="events.list.title" bulkActionButtons={false} {...props}>
       <Datagrid rowClick="show">
         <TextField
           source={getTranslatedField('name', locale)}

--- a/src/domain/events/mutations/EventMutations.ts
+++ b/src/domain/events/mutations/EventMutations.ts
@@ -61,3 +61,11 @@ export const publishEventMutation = gql`
     }
   }
 `;
+
+export const deleteEventMutation = gql`
+  mutation deleteEvent($input: DeleteEventMutationInput!) {
+    deleteEvent(input: $input) {
+      clientMutationId
+    }
+  }
+`;

--- a/src/domain/venues/VenueEdit.tsx
+++ b/src/domain/venues/VenueEdit.tsx
@@ -5,6 +5,9 @@ import {
   useTranslate,
   SimpleForm,
   required,
+  Toolbar,
+  SaveButton,
+  DeleteButton,
 } from 'react-admin';
 
 import { Language } from '../../api/generatedTypes/globalTypes';
@@ -18,6 +21,17 @@ const VenueEditTitle = ({ record }: any) => {
   );
 };
 
+const VenueEditToolbar = (props: any) => {
+  return (
+    <Toolbar style={{ justifyContent: 'space-between' }} {...props}>
+      <SaveButton />
+      <DeleteButton
+        disabled={Boolean(props.record.occurrences.pageInfo.startCursor)}
+      />
+    </Toolbar>
+  );
+};
+
 const VenueEdit = (props: any) => {
   const translate = useTranslate();
   const [selectedLanguage, selectLanguage] = useState(Language.FI);
@@ -25,7 +39,11 @@ const VenueEdit = (props: any) => {
 
   return (
     <Edit title={<VenueEditTitle />} {...props}>
-      <SimpleForm redirect="show" validate={validateVenue}>
+      <SimpleForm
+        redirect="show"
+        validate={validateVenue}
+        toolbar={<VenueEditToolbar />}
+      >
         <LanguageTabs
           selectedLanguage={selectedLanguage}
           onSelect={selectLanguage}

--- a/src/domain/venues/VenueList.tsx
+++ b/src/domain/venues/VenueList.tsx
@@ -13,7 +13,7 @@ const VenueList = (props: any) => {
   const translate = useTranslate();
   const locale = useLocale();
   return (
-    <List title={translate('venues.list.title')} {...props}>
+    <List title="venues.list.title" bulkActionButtons={false} {...props}>
       <Datagrid rowClick="show">
         <TextField
           source={getTranslatedField('name', locale)}

--- a/src/domain/venues/api/VenueApi.ts
+++ b/src/domain/venues/api/VenueApi.ts
@@ -9,6 +9,7 @@ import { venuesQuery, venueQuery } from '../query/VenueQueries';
 import {
   addVenueMutation,
   updateVenueMutation,
+  deleteVenueMutation,
 } from './mutations/venueMutations';
 import { MethodHandler, MethodHandlerParams } from '../../../api/types';
 import {
@@ -65,4 +66,12 @@ const updateVenue: MethodHandler = async (params: MethodHandlerParams) => {
     : null;
 };
 
-export { getVenues, getVenue, addVenue, updateVenue };
+const deleteVenue: MethodHandler = async (params: MethodHandlerParams) => {
+  await mutationHandler({
+    mutation: deleteVenueMutation,
+    variables: { input: { id: params.id } },
+  });
+  return { id: params.id };
+};
+
+export { getVenues, getVenue, addVenue, updateVenue, deleteVenue };

--- a/src/domain/venues/api/mutations/venueMutations.ts
+++ b/src/domain/venues/api/mutations/venueMutations.ts
@@ -37,3 +37,11 @@ export const updateVenueMutation = gql`
     }
   }
 `;
+
+export const deleteVenueMutation = gql`
+  mutation deleteVenue($input: DeleteVenueMutationInput!) {
+    deleteVenue(input: $input) {
+      clientMutationId
+    }
+  }
+`;

--- a/src/domain/venues/query/VenueQueries.ts
+++ b/src/domain/venues/query/VenueQueries.ts
@@ -11,6 +11,11 @@ export const venuesQuery = gql`
             address
             languageCode
           }
+          occurrences {
+            pageInfo {
+              startCursor
+            }
+          }
         }
       }
     }
@@ -29,6 +34,11 @@ export const venueQuery = gql`
         accessibilityInfo
         arrivalInstructions
         additionalInfo
+      }
+      occurrences {
+        pageInfo {
+          startCursor
+        }
       }
     }
   }


### PR DESCRIPTION
* Only venues that have no event occurrences using them can be deleted.
* Only unpublished events can be deleted.

Also disabled bulk delete actions from the UI because those are not implemented.