### PR TITLE
KK-545 | Add occurrence capacityOverride field

### DIFF
--- a/src/api/generatedTypes/Occurrence.ts
+++ b/src/api/generatedTypes/Occurrence.ts
@@ -101,6 +101,11 @@ export interface Occurrence_occurrence {
   time: any;
   event: Occurrence_occurrence_event;
   enrolmentCount: number;
+  capacity: number | null;
+  /**
+   * When set will be used as the capacity of this occurrence instead of the value coming from the event.
+   */
+  capacityOverride: number | null;
   venue: Occurrence_occurrence_venue;
   enrolments: Occurrence_occurrence_enrolments;
 }

--- a/src/api/generatedTypes/Occurrences.ts
+++ b/src/api/generatedTypes/Occurrences.ts
@@ -101,6 +101,11 @@ export interface Occurrences_occurrences_edges_node {
   time: any;
   event: Occurrences_occurrences_edges_node_event;
   enrolmentCount: number;
+  capacity: number | null;
+  /**
+   * When set will be used as the capacity of this occurrence instead of the value coming from the event.
+   */
+  capacityOverride: number | null;
   venue: Occurrences_occurrences_edges_node_venue;
   enrolments: Occurrences_occurrences_edges_node_enrolments;
 }

--- a/src/api/generatedTypes/addOccurrence.ts
+++ b/src/api/generatedTypes/addOccurrence.ts
@@ -43,6 +43,11 @@ export interface addOccurrence_addOccurrence_occurrence {
   event: addOccurrence_addOccurrence_occurrence_event;
   enrolmentCount: number;
   venue: addOccurrence_addOccurrence_occurrence_venue;
+  capacity: number | null;
+  /**
+   * When set will be used as the capacity of this occurrence instead of the value coming from the event.
+   */
+  capacityOverride: number | null;
 }
 
 export interface addOccurrence_addOccurrence {

--- a/src/api/generatedTypes/globalTypes.ts
+++ b/src/api/generatedTypes/globalTypes.ts
@@ -37,6 +37,7 @@ export interface AddOccurrenceMutationInput {
   eventId: string;
   venueId: string;
   occurrenceLanguage?: Language | null;
+  capacityOverride?: number | null;
   clientMutationId?: string | null;
 }
 
@@ -97,6 +98,7 @@ export interface UpdateOccurrenceMutationInput {
   eventId?: string | null;
   venueId?: string | null;
   occurrenceLanguage?: Language | null;
+  capacityOverride?: number | null;
   clientMutationId?: string | null;
 }
 

--- a/src/api/generatedTypes/updateOccurrence.ts
+++ b/src/api/generatedTypes/updateOccurrence.ts
@@ -43,6 +43,11 @@ export interface updateOccurrence_updateOccurrence_occurrence {
   event: updateOccurrence_updateOccurrence_occurrence_event;
   enrolmentCount: number;
   venue: updateOccurrence_updateOccurrence_occurrence_venue;
+  capacity: number | null;
+  /**
+   * When set will be used as the capacity of this occurrence instead of the value coming from the event.
+   */
+  capacityOverride: number | null;
 }
 
 export interface updateOccurrence_updateOccurrence {

--- a/src/common/components/sanitizedGrid/SanitizedGrid.tsx
+++ b/src/common/components/sanitizedGrid/SanitizedGrid.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Grid } from '@material-ui/core';
+
+const SanitizedGrid = (props: any) => {
+  const { basePath, ...sanitizedProps } = props;
+  return <Grid {...sanitizedProps} />;
+};
+
+export default SanitizedGrid;

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -182,6 +182,10 @@
       "capacity": {
         "label": "Capacity"
       },
+      "capacityOverride": {
+        "label": "Occurrence capacity",
+        "helperText": ""
+      },
       "children": {
         "label": "Enrolled children"
       },

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -65,7 +65,7 @@
     },
     "fields": {
       "capacityPerOccurrence": {
-        "helperText": "Montako ilmoittautumista tapahtumaesiintymään vastaanotetaan. Huomioithan että todellinen osallistujamäärä on kapasiteetti kerrottuna sillä montako henkilöä kutsua kohti tapahtumaan voi osallistua.",
+        "helperText": "Montako ilmoittautumista tapahtumaesiintymään vastaanotetaan. Huomioithan että todellinen osallistujamäärä on kapasiteetti kerrottuna sillä montako henkilöä kutsua kohti tapahtumaan voi osallistua. Voit halutessasi muuttaa kapasiteettia myös esiintymäkohtaisesti.",
         "label": "Esiintymän kapasiteetti"
       },
       "description": {
@@ -181,6 +181,10 @@
     "fields": {
       "capacity": {
         "label": "Paikkoja"
+      },
+      "capacityOverride": {
+        "label": "Esiintymäkohtainen kapasiteetti",
+        "helperText": "Voit halutessasi muuttaa yksittäisen esiintymän kapasiteettia tapahtuman oletusarvosta (%{capacityPerOccurrence}). Tämä ei vaikuta muihin esiintymiin."
       },
       "children": {
         "label": "Osallistujat"

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -207,7 +207,7 @@ const EventShow: FunctionComponent = (props: any) => {
                 <TextField source="translations.FI.name" />
               </ReferenceField>
               <NumberField
-                source="event.capacityPerOccurrence"
+                source="capacity"
                 label="occurrences.fields.capacity.label"
               />
               <NumberField

--- a/src/domain/occurrences/OccurrenceEdit.tsx
+++ b/src/domain/occurrences/OccurrenceEdit.tsx
@@ -8,12 +8,16 @@ import {
   SaveButton,
   DeleteButton,
   DeleteWithConfirmButton,
+  NumberInput,
+  minValue,
+  useTranslate,
 } from 'react-admin';
 import { parse } from 'query-string';
 import { Grid } from '@material-ui/core';
 
 import DateTimeTextInput from '../../common/components/dateTimeTextField/DateTimeTextField';
 import KukkuuEdit from '../../common/components/kukkuuEdit/KukkuuEdit';
+import SanitizedGrid from '../../common/components/sanitizedGrid/SanitizedGrid';
 
 const OccurrenceEditToolbar = (props: any) => {
   const redirect = `/events/${props.record.event.id}/show/1`;
@@ -49,6 +53,31 @@ const OccurrenceEditReferenceInput = (props: any) => {
   );
 };
 
+const validateCapacityOverride = [minValue(0)];
+
+const OccurrenceEditCapacityOverrideInput = (props: any) => {
+  const translate = useTranslate();
+  return (
+    <SanitizedGrid container spacing={1}>
+      <Grid item lg={6}>
+        <NumberInput
+          {...props}
+          style={{ width: '100%' }}
+          source="capacityOverride"
+          label="occurrences.fields.capacityOverride.label"
+          helperText={translate(
+            'occurrences.fields.capacityOverride.helperText',
+            {
+              capacityPerOccurrence: props.record.event.capacityPerOccurrence.toString(),
+            }
+          )}
+          validate={validateCapacityOverride}
+        />
+      </Grid>
+    </SanitizedGrid>
+  );
+};
+
 const OccurrenceEdit = (props: any) => {
   const { event_id: eventId } = parse(props.location.search);
   const redirect = eventId ? `/events/${eventId}/show/1` : 'show';
@@ -77,6 +106,7 @@ const OccurrenceEdit = (props: any) => {
               helperText="occurrences.fields.venue.helperText"
             />
           </OccurrenceEditReferenceInput>
+          <OccurrenceEditCapacityOverrideInput />
         </SimpleForm>
       </KukkuuEdit>
     </Grid>

--- a/src/domain/occurrences/OccurrenceShow.tsx
+++ b/src/domain/occurrences/OccurrenceShow.tsx
@@ -110,7 +110,7 @@ const OccurrenceShow = (props: any) => {
           <TextField source="translations.FI.name" />
         </ReferenceField>
         <NumberField
-          source="event.capacityPerOccurrence"
+          source="capacity"
           label="occurrences.fields.capacity.label"
         />
         <ArrayField

--- a/src/domain/occurrences/api/OccurrenceApi.ts
+++ b/src/domain/occurrences/api/OccurrenceApi.ts
@@ -64,13 +64,21 @@ const addOccurrence: MethodHandler = async (params: MethodHandlerParams) => {
 
 const updateOccurrence: MethodHandler = async (params: MethodHandlerParams) => {
   const { ...localUpdateData } = params.data;
-  const { id, timeField, date, venue, event } = localUpdateData;
+  const {
+    id,
+    timeField,
+    date,
+    venue,
+    event,
+    capacityOverride,
+  } = localUpdateData;
 
   const data = {
     id,
     venueId: venue.id,
     time: normalizeTime(date, timeField),
     eventId: event.id,
+    capacityOverride,
   };
 
   const response = await mutationHandler({

--- a/src/domain/occurrences/mutations/OccurrenceMutations.ts
+++ b/src/domain/occurrences/mutations/OccurrenceMutations.ts
@@ -19,6 +19,8 @@ export const addOccurrenceMutation = gql`
             name
           }
         }
+        capacity
+        capacityOverride
       }
     }
   }
@@ -41,6 +43,32 @@ export const updateOccurrenceMutation = gql`
           translations {
             languageCode
             name
+          }
+        }
+        capacity
+        capacityOverride
+        enrolments {
+          edges {
+            node {
+              id
+              attended
+              child {
+                firstName
+                lastName
+                birthdate
+                guardians {
+                  edges {
+                    node {
+                      id
+                      email
+                      firstName
+                      lastName
+                      language
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/src/domain/occurrences/queries/OccurrenceQueries.ts
+++ b/src/domain/occurrences/queries/OccurrenceQueries.ts
@@ -14,6 +14,8 @@ export const occurrencesQuery = gql`
             publishedAt
           }
           enrolmentCount
+          capacity
+          capacityOverride
           venue {
             id
             translations {
@@ -63,6 +65,8 @@ export const occurrenceQuery = gql`
         publishedAt
       }
       enrolmentCount
+      capacity
+      capacityOverride
       venue {
         id
         translations {


### PR DESCRIPTION
* Changed occurrence capacity to be read from occurrence `capacity` instead of event `capacityPerOccurrence` when showing occurrence info
* Enabled setting occurrence `capacityOverride` in add and edit views