### PR TITLE
KK-592 | Add manual messages resource

### DIFF
--- a/src/api/dataProvider.ts
+++ b/src/api/dataProvider.ts
@@ -30,6 +30,7 @@ import {
 import { getChild, getChildren } from '../domain/children/api/ChildApi';
 import { getMyAdminProfile } from '../domain/profile/api';
 import { getProject } from '../domain/dashboard/api';
+import ManualMessagesApi from '../domain/manualMessages/api/manualMessagesApi';
 
 const METHOD_HANDLERS: MethodHandlers = {
   venues: {
@@ -64,6 +65,15 @@ const METHOD_HANDLERS: MethodHandlers = {
   },
   projects: {
     ONE: getProject,
+  },
+  manualMessages: {
+    LIST: ManualMessagesApi.getManualMessages,
+    ONE: ManualMessagesApi.getManualMessage,
+    MANY: ManualMessagesApi.getManualMessages,
+    CREATE: ManualMessagesApi.addManualMessage,
+    UPDATE: ManualMessagesApi.updateManualMessage,
+    DELETE: ManualMessagesApi.deleteManualMessage,
+    SEND: ManualMessagesApi.sendManualMessage,
   },
 };
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -11,7 +11,8 @@ export type Resource =
   | 'events'
   | 'occurrences'
   | 'children'
-  | 'projects';
+  | 'projects'
+  | 'manualMessages';
 
 export type Method =
   | 'LIST'
@@ -23,7 +24,8 @@ export type Method =
   | 'UPDATE_MANY'
   | 'DELETE'
   | 'DELETE_MANY'
-  | 'PUBLISH';
+  | 'PUBLISH'
+  | 'SEND';
 
 export type Record = { [index: string]: any; id: string };
 

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -164,6 +164,11 @@
     "FI": "Finnish",
     "SV": "Swedish"
   },
+  "manualMessages": {
+    "list": {
+      "title": "Messages"
+    }
+  },
   "occurrences": {
     "addOccurrenceButton": {
       "label": "Add occurrence"

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -164,6 +164,11 @@
     "FI": "suomi",
     "SV": "ruotsi"
   },
+  "manualMessages": {
+    "list": {
+      "title": "Viestit"
+    }
+  },
   "occurrences": {
     "addOccurrenceButton": {
       "label": "Lisää esiintymä"

--- a/src/domain/application/App.tsx
+++ b/src/domain/application/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Admin, Resource, useTranslate } from 'react-admin';
 import PlaceIcon from '@material-ui/icons/Place';
 import EventIcon from '@material-ui/icons/Event';
+import ManualMessageIcon from '@material-ui/icons/EmailOutlined';
 import { createBrowserHistory as createHistory } from 'history';
 import ChildCareIcon from '@material-ui/icons/ChildCare';
 
@@ -26,6 +27,10 @@ import OccurrenceShow from '../occurrences/OccurrenceShow';
 import OccurrenceEdit from '../occurrences/OccurrenceEdit';
 import ChildShow from '../children/ChildShow';
 import KukkuuLayout from '../../common/components/layout/KukkuuLayout';
+import ManualMessagesList from '../manualMessages/list/ManualMessagesList';
+import ManualMessagesDetail from '../manualMessages/detail/ManualMessagesDetail';
+import ManualMessagesEdit from '../manualMessages/edit/ManualMessagesEdit';
+import ManualMessagesCreate from '../manualMessages/create/ManualMessagesCreate';
 
 const history = createHistory();
 
@@ -73,6 +78,15 @@ const App: React.FC = () => {
         create={OccurrenceCreate}
         show={OccurrenceShow}
         edit={OccurrenceEdit}
+      />
+      <Resource
+        name="manual-messages"
+        options={{ label: translate('manualMessages.list.title') }}
+        icon={ManualMessageIcon}
+        list={ManualMessagesList}
+        show={ManualMessagesDetail}
+        create={ManualMessagesCreate}
+        edit={ManualMessagesEdit}
       />
     </Admin>
   );

--- a/src/domain/manualMessages/api/manualMessagesApi.ts
+++ b/src/domain/manualMessages/api/manualMessagesApi.ts
@@ -1,0 +1,43 @@
+import { MethodHandlerResponse, MethodHandlerParams } from '../../../api/types';
+
+function getManualMessages(
+  params: MethodHandlerParams
+): Promise<MethodHandlerResponse | null> {
+  return Promise.resolve(null);
+}
+function getManualMessage(
+  params: MethodHandlerParams
+): Promise<MethodHandlerResponse | null> {
+  return Promise.resolve(null);
+}
+function addManualMessage(
+  params: MethodHandlerParams
+): Promise<MethodHandlerResponse | null> {
+  return Promise.resolve(null);
+}
+function updateManualMessage(
+  params: MethodHandlerParams
+): Promise<MethodHandlerResponse | null> {
+  return Promise.resolve(null);
+}
+function deleteManualMessage(
+  params: MethodHandlerParams
+): Promise<MethodHandlerResponse | null> {
+  return Promise.resolve(null);
+}
+function sendManualMessage(
+  params: MethodHandlerParams
+): Promise<MethodHandlerResponse | null> {
+  return Promise.resolve(null);
+}
+
+const manualMessagesApi = {
+  getManualMessages,
+  getManualMessage,
+  addManualMessage,
+  updateManualMessage,
+  deleteManualMessage,
+  sendManualMessage,
+};
+
+export default manualMessagesApi;

--- a/src/domain/manualMessages/create/ManualMessagesCreate.tsx
+++ b/src/domain/manualMessages/create/ManualMessagesCreate.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ManualMessagesCreate = () => {
+  return <>ManualMessagesCreate</>;
+};
+
+export default ManualMessagesCreate;

--- a/src/domain/manualMessages/detail/ManualMessagesDetail.tsx
+++ b/src/domain/manualMessages/detail/ManualMessagesDetail.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ManualMessagesDetail = () => {
+  return <>ManualMessagesDetail</>;
+};
+
+export default ManualMessagesDetail;

--- a/src/domain/manualMessages/edit/ManualMessagesEdit.tsx
+++ b/src/domain/manualMessages/edit/ManualMessagesEdit.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ManualMessagesEdit = () => {
+  return <>ManualMessagesEdit</>;
+};
+
+export default ManualMessagesEdit;

--- a/src/domain/manualMessages/list/ManualMessagesList.tsx
+++ b/src/domain/manualMessages/list/ManualMessagesList.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ManualMessagesList = () => {
+  return <>ManualMessagesList</>;
+};
+
+export default ManualMessagesList;


### PR DESCRIPTION
## Description

Adds the manual message resource to the UI. Adds placeholders for list, details, edit and create views, and also adds a stub of the manual messages API.

## Context

Initialising the resource views allows for the views themselves to be developed more independently.

[KK-592](https://helsinkisolutionoffice.atlassian.net/browse/KK-592)