### PR TITLE
KK-592 | Add list view for messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ra-language-finnish": "^3.6.0",
     "ra-language-swedish": "^1.0.0",
     "react": "^16.13.1",
-    "react-admin": "^3.8.5",
+    "react-admin": "3.9.4",
     "react-apollo": "^3.1.5",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.1",

--- a/src/api/dataProvider.ts
+++ b/src/api/dataProvider.ts
@@ -30,7 +30,7 @@ import {
 import { getChild, getChildren } from '../domain/children/api/ChildApi';
 import { getMyAdminProfile } from '../domain/profile/api';
 import { getProject } from '../domain/dashboard/api';
-import ManualMessagesApi from '../domain/manualMessages/api/manualMessagesApi';
+import MessagesApi from '../domain/messages/api/messagesApi';
 
 const METHOD_HANDLERS: MethodHandlers = {
   venues: {
@@ -66,14 +66,14 @@ const METHOD_HANDLERS: MethodHandlers = {
   projects: {
     ONE: getProject,
   },
-  manualMessages: {
-    LIST: ManualMessagesApi.getManualMessages,
-    ONE: ManualMessagesApi.getManualMessage,
-    MANY: ManualMessagesApi.getManualMessages,
-    CREATE: ManualMessagesApi.addManualMessage,
-    UPDATE: ManualMessagesApi.updateManualMessage,
-    DELETE: ManualMessagesApi.deleteManualMessage,
-    SEND: ManualMessagesApi.sendManualMessage,
+  messages: {
+    LIST: MessagesApi.getMessages,
+    ONE: MessagesApi.getMessage,
+    MANY: MessagesApi.getMessages,
+    CREATE: MessagesApi.addMessage,
+    UPDATE: MessagesApi.updateMessage,
+    DELETE: MessagesApi.deleteMessage,
+    SEND: MessagesApi.sendMessage,
   },
 };
 

--- a/src/api/generatedTypes/Messages.ts
+++ b/src/api/generatedTypes/Messages.ts
@@ -1,0 +1,49 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RecipientSelectionEnum } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: Messages
+// ====================================================
+
+export interface Messages_messages_edges_node_event {
+  name: string | null;
+}
+
+export interface Messages_messages_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  subject: string | null;
+  bodyText: string | null;
+  recipientSelection: RecipientSelectionEnum | null;
+  recipientCount: number | null;
+  sentAt: any | null;
+  event: Messages_messages_edges_node_event | null;
+}
+
+export interface Messages_messages_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: Messages_messages_edges_node | null;
+}
+
+export interface Messages_messages {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (Messages_messages_edges | null)[];
+}
+
+export interface Messages {
+  messages: Messages_messages | null;
+}
+
+export interface MessagesVariables {
+  projectId?: string | null;
+}

--- a/src/api/generatedTypes/globalTypes.ts
+++ b/src/api/generatedTypes/globalTypes.ts
@@ -22,6 +22,14 @@ export enum Language {
   SV = "SV",
 }
 
+export enum RecipientSelectionEnum {
+  ALL = "ALL",
+  ATTENDED = "ATTENDED",
+  ENROLLED = "ENROLLED",
+  INVITED = "INVITED",
+  SUBSCRIBED_TO_FREE_SPOT_MESSAGE = "SUBSCRIBED_TO_FREE_SPOT_MESSAGE",
+}
+
 export interface AddEventMutationInput {
   translations?: (EventTranslationsInput | null)[] | null;
   duration?: number | null;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -12,7 +12,7 @@ export type Resource =
   | 'occurrences'
   | 'children'
   | 'projects'
-  | 'manualMessages';
+  | 'messages';
 
 export type Method =
   | 'LIST'

--- a/src/api/utils/apiUtils.ts
+++ b/src/api/utils/apiUtils.ts
@@ -44,7 +44,7 @@ export const queryHandler = async (
       console.error(error);
       Sentry.captureException(error);
     }
-    throw new HttpError(error.message || API_ERROR_MESSAGE);
+    throw new HttpError(error.message || API_ERROR_MESSAGE, error.status);
   }
 };
 
@@ -57,7 +57,7 @@ export const mutationHandler = async (
     // eslint-disable-next-line no-console
     console.error(error);
     Sentry.captureException(error);
-    throw new HttpError(error.message || API_ERROR_MESSAGE);
+    throw new HttpError(error.message || API_ERROR_MESSAGE, error.status);
   }
 };
 

--- a/src/common/components/dateTimeTextField/DateTimeTextField.tsx
+++ b/src/common/components/dateTimeTextField/DateTimeTextField.tsx
@@ -23,6 +23,8 @@ const BoundedTextField = (props: Props & TextFieldProps) => {
     input: { name, onChange },
     meta: { touched, error },
     isRequired,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
   } = useInput(props);
 
   return (

--- a/src/common/components/kukkuuListPage/KukkuuListPage.tsx
+++ b/src/common/components/kukkuuListPage/KukkuuListPage.tsx
@@ -1,0 +1,29 @@
+import React, { ReactNode } from 'react';
+import { Datagrid, ResourceComponentPropsWithId } from 'react-admin';
+import { CardHeader } from '@material-ui/core';
+
+import KukkuuList from '../kukkuuList/KukkuuList';
+
+type Props = {
+  pageTitle: string;
+  children: ReactNode;
+  reactAdminProps: ResourceComponentPropsWithId;
+};
+
+const KukkuuListPage = ({ pageTitle, children, reactAdminProps }: Props) => {
+  return (
+    <>
+      <CardHeader title={pageTitle} />
+      <KukkuuList
+        bulkActionButtons={false}
+        pagination={false}
+        exporter={false}
+        {...reactAdminProps}
+      >
+        <Datagrid rowClick="show">{children}</Datagrid>
+      </KukkuuList>
+    </>
+  );
+};
+
+export default KukkuuListPage;

--- a/src/common/components/publishedField/PublishedField.tsx
+++ b/src/common/components/publishedField/PublishedField.tsx
@@ -1,0 +1,39 @@
+import React, { ReactElement, ReactNode } from 'react';
+import Typography from '@material-ui/core/Typography';
+import { useTranslate, useLocale } from 'react-admin';
+import get from 'lodash/get';
+
+type Props = {
+  label: string;
+  record?: unknown;
+  placeholder?: string | null;
+  source: string;
+  render?: (date: Date) => ReactNode;
+  className?: string;
+};
+
+const PublishedField = ({
+  record,
+  placeholder = null,
+  source,
+  render,
+  className,
+}: Props): ReactElement | null => {
+  const translate = useTranslate();
+  const locale = useLocale();
+
+  if (!record) return null;
+
+  const sourceData = get(record, source) || new Date();
+  const date = new Date(sourceData);
+
+  return (
+    <Typography variant="body2" className={className}>
+      {sourceData && render && render(date)}
+      {sourceData && !render && date.toLocaleString(locale)}
+      {!sourceData && placeholder && translate(placeholder)}
+    </Typography>
+  );
+};
+
+export default PublishedField;

--- a/src/common/materialUI/kukkuuStyles.ts
+++ b/src/common/materialUI/kukkuuStyles.ts
@@ -2,4 +2,7 @@ export const kukkuuToolbar = {
   '&> .MuiToolbar-regular  ': {
     justifyContent: 'flex-start',
   },
+  '& .MuiTableCell-head': {
+    fontWeight: 600,
+  },
 };

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -164,7 +164,43 @@
     "FI": "Finnish",
     "SV": "Swedish"
   },
-  "manualMessages": {
+  "messages": {
+    "fields": {
+      "recipientSelection": {
+        "choices": {
+          "ALL": {
+            "label": "All"
+          },
+          "INVITED": {
+            "label": "Invited"
+          },
+          "ENROLLED": {
+            "label": "Enrolled"
+          },
+          "ATTENDED": {
+            "label": "Attended"
+          },
+          "SUBSCRIBED_TO_FREE_SPOT_MESSAGE": {
+            "label": "Subscribed to free spot message"
+          }
+        },
+        "label": "Recipients"
+      },
+      "subject": {
+        "label": "Name"
+      },
+      "event": {
+        "label": "Event"
+      },
+      "recipientCount": {
+        "label": "Recipient count"
+      },
+      "sentAt": {
+        "label": "Published",
+        "sent": "Sent",
+        "notSent": "Not sent"
+      }
+    },
     "list": {
       "title": "Messages"
     }

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -164,7 +164,43 @@
     "FI": "suomi",
     "SV": "ruotsi"
   },
-  "manualMessages": {
+  "messages": {
+    "fields": {
+      "recipientSelection": {
+        "choices": {
+          "ALL": {
+            "label": "Kaikki"
+          },
+          "INVITED": {
+            "label": "Kutsutut"
+          },
+          "ENROLLED": {
+            "label": "Ilmoittautuneet"
+          },
+          "ATTENDED": {
+            "label": "Saapuneet"
+          },
+          "SUBSCRIBED_TO_FREE_SPOT_MESSAGE": {
+            "label": "Ilmoituksen tilanneet"
+          }
+        },
+        "label": "Vastaanottajat"
+      },
+      "subject": {
+        "label": "Nimi"
+      },
+      "event": {
+        "label": "Tapahtuma"
+      },
+      "recipientCount": {
+        "label": "Vastaanottajia"
+      },
+      "sentAt": {
+        "label": "Julkaisu",
+        "sent": "Lähetetty",
+        "notSent": "Ei lähetetty"
+      }
+    },
     "list": {
       "title": "Viestit"
     }

--- a/src/domain/application/App.tsx
+++ b/src/domain/application/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Admin, Resource, useTranslate } from 'react-admin';
 import PlaceIcon from '@material-ui/icons/Place';
 import EventIcon from '@material-ui/icons/Event';
-import ManualMessageIcon from '@material-ui/icons/EmailOutlined';
+import MessageIcon from '@material-ui/icons/EmailOutlined';
 import { createBrowserHistory as createHistory } from 'history';
 import ChildCareIcon from '@material-ui/icons/ChildCare';
 
@@ -27,10 +27,10 @@ import OccurrenceShow from '../occurrences/OccurrenceShow';
 import OccurrenceEdit from '../occurrences/OccurrenceEdit';
 import ChildShow from '../children/ChildShow';
 import KukkuuLayout from '../../common/components/layout/KukkuuLayout';
-import ManualMessagesList from '../manualMessages/list/ManualMessagesList';
-import ManualMessagesDetail from '../manualMessages/detail/ManualMessagesDetail';
-import ManualMessagesEdit from '../manualMessages/edit/ManualMessagesEdit';
-import ManualMessagesCreate from '../manualMessages/create/ManualMessagesCreate';
+import MessagesList from '../messages/list/MessagesList';
+import MessagesDetail from '../messages/detail/MessagesDetail';
+import MessagesEdit from '../messages/edit/MessagesEdit';
+import MessagesCreate from '../messages/create/MessagesCreate';
 
 const history = createHistory();
 
@@ -85,13 +85,13 @@ const App: React.FC = () => {
         edit={OccurrenceEdit}
       />
       <Resource
-        name="manual-messages"
-        options={{ label: translate('manualMessages.list.title') }}
-        icon={ManualMessageIcon}
-        list={ManualMessagesList}
-        show={ManualMessagesDetail}
-        create={ManualMessagesCreate}
-        edit={ManualMessagesEdit}
+        name="messages"
+        options={{ label: translate('messages.list.title') }}
+        icon={MessageIcon}
+        list={MessagesList}
+        show={MessagesDetail}
+        create={MessagesCreate}
+        edit={MessagesEdit}
       />
     </Admin>
   );

--- a/src/domain/application/App.tsx
+++ b/src/domain/application/App.tsx
@@ -39,6 +39,11 @@ const App: React.FC = () => {
   return (
     <Admin
       layout={KukkuuLayout}
+      // FIXME: In version 3.9.0 typescript support was added into
+      // react-admin and our implementation of dataProvider is not type
+      // compatible.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
       dataProvider={dataProvider}
       i18nProvider={i18nProvider}
       theme={theme}

--- a/src/domain/children/ChildList.tsx
+++ b/src/domain/children/ChildList.tsx
@@ -33,8 +33,10 @@ const ChildList = (props: any) => {
         <Datagrid rowClick="show">
           <FunctionField
             label="children.fields.name.label"
-            render={(record: Child) =>
-              `${record.firstName} ${record.lastName}`.trim()
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
+            render={(record?: Child) =>
+              record && `${record.firstName} ${record.lastName}`.trim()
             }
           />
           <DateField

--- a/src/domain/children/ChildShow.tsx
+++ b/src/domain/children/ChildShow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactText } from 'react';
 import {
   TextField,
   SimpleShowLayout,
@@ -39,6 +39,8 @@ const ChildShow = (props: any) => {
         <SimpleShowLayout>
           <FunctionField
             label="children.fields.name.label"
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
             render={(record: Child) =>
               `${record.firstName} ${record.lastName}`.trim()
             }
@@ -59,7 +61,10 @@ const ChildShow = (props: any) => {
           />
           <FunctionField
             label="children.fields.guardians.label"
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
             render={(record: Child) =>
+              record &&
               `${record.guardians.edges[0]?.node?.firstName} ${record.guardians.edges[0]?.node?.lastName}`.trim()
             }
           />
@@ -76,8 +81,10 @@ const ChildShow = (props: any) => {
             label="children.fields.occurrences.label"
           >
             <Datagrid
+              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+              // @ts-ignore
               rowClick={(
-                id: string,
+                id: ReactText,
                 basePath: string,
                 record: OccurrenceEdges
               ) =>

--- a/src/domain/events/create/EventCreate.tsx
+++ b/src/domain/events/create/EventCreate.tsx
@@ -40,6 +40,8 @@ const EventCreate = (props: any) => {
           <SimpleForm
             variant="outlined"
             redirect="show"
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
             validate={validateEvent}
           >
             <LanguageTabs
@@ -56,12 +58,16 @@ const EventCreate = (props: any) => {
               source={`${translation}.imageAltText`}
               label="events.fields.imageAltText.label"
               helperText="events.fields.imageAltText.helperText"
+              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+              // @ts-ignore
               validate={null}
               fullWidth
             />
             <TextInput
               source={`${translation}.name`}
               label="events.fields.name.label"
+              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+              // @ts-ignore
               validate={selectedLanguage === Language.FI ? required() : null}
               fullWidth
             />

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -216,6 +216,8 @@ const EventShow: FunctionComponent = (props: any) => {
                 label="occurrences.fields.enrolmentsCount.label"
               />
               <FunctionField
+                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                // @ts-ignore
                 render={(record: Occurrence) =>
                   record.freeSpotNotificationSubscriptions.edges.length || '0'
                 }

--- a/src/domain/events/edit/EventEdit.tsx
+++ b/src/domain/events/edit/EventEdit.tsx
@@ -49,6 +49,8 @@ const EventEdit = (props: any) => {
           <SimpleForm
             variant="outlined"
             redirect="show"
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
             validate={validateVenue}
             toolbar={<EventEditToolbar />}
           >
@@ -67,12 +69,16 @@ const EventEdit = (props: any) => {
               source={`${translation}.imageAltText`}
               label="events.fields.imageAltText.label"
               helperText="events.fields.imageAltText.helperText"
+              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+              // @ts-ignore
               validate={null}
               fullWidth
             />
             <TextInput
               source={`${translation}.name`}
               label="events.fields.name.label"
+              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+              // @ts-ignore
               validate={selectedLanguage === Language.FI ? required() : null}
               fullWidth
               helperText="Tähän laitetaan tapahtuman nimi"

--- a/src/domain/events/list/EventList.tsx
+++ b/src/domain/events/list/EventList.tsx
@@ -46,6 +46,8 @@ const EventList = (props: any) => {
           <FunctionField
             label="events.fields.totalCapacity.label"
             textAlign="right"
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
             render={(record: Event) =>
               `${
                 record.capacityPerOccurrence * record.occurrences.edges.length

--- a/src/domain/manualMessages/create/ManualMessagesCreate.tsx
+++ b/src/domain/manualMessages/create/ManualMessagesCreate.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const ManualMessagesCreate = () => {
-  return <>ManualMessagesCreate</>;
-};
-
-export default ManualMessagesCreate;

--- a/src/domain/manualMessages/detail/ManualMessagesDetail.tsx
+++ b/src/domain/manualMessages/detail/ManualMessagesDetail.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const ManualMessagesDetail = () => {
-  return <>ManualMessagesDetail</>;
-};
-
-export default ManualMessagesDetail;

--- a/src/domain/manualMessages/edit/ManualMessagesEdit.tsx
+++ b/src/domain/manualMessages/edit/ManualMessagesEdit.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const ManualMessagesEdit = () => {
-  return <>ManualMessagesEdit</>;
-};
-
-export default ManualMessagesEdit;

--- a/src/domain/manualMessages/list/ManualMessagesList.tsx
+++ b/src/domain/manualMessages/list/ManualMessagesList.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const ManualMessagesList = () => {
-  return <>ManualMessagesList</>;
-};
-
-export default ManualMessagesList;

--- a/src/domain/messages/api/messagesApi.ts
+++ b/src/domain/messages/api/messagesApi.ts
@@ -1,43 +1,49 @@
 import { MethodHandlerResponse, MethodHandlerParams } from '../../../api/types';
+import { queryHandler, handleApiConnection } from '../../../api/utils/apiUtils';
+import { MessagesQuery } from '../queries/MessageQueries';
 
-function getManualMessages(
+async function getMessages(
+  params: MethodHandlerParams
+): Promise<MethodHandlerResponse | null> {
+  const response = await queryHandler({
+    query: MessagesQuery,
+  });
+
+  return handleApiConnection(response.data.messages);
+}
+function getMessage(
   params: MethodHandlerParams
 ): Promise<MethodHandlerResponse | null> {
   return Promise.resolve(null);
 }
-function getManualMessage(
+function addMessage(
   params: MethodHandlerParams
 ): Promise<MethodHandlerResponse | null> {
   return Promise.resolve(null);
 }
-function addManualMessage(
+function updateMessage(
   params: MethodHandlerParams
 ): Promise<MethodHandlerResponse | null> {
   return Promise.resolve(null);
 }
-function updateManualMessage(
+function deleteMessage(
   params: MethodHandlerParams
 ): Promise<MethodHandlerResponse | null> {
   return Promise.resolve(null);
 }
-function deleteManualMessage(
-  params: MethodHandlerParams
-): Promise<MethodHandlerResponse | null> {
-  return Promise.resolve(null);
-}
-function sendManualMessage(
+function sendMessage(
   params: MethodHandlerParams
 ): Promise<MethodHandlerResponse | null> {
   return Promise.resolve(null);
 }
 
-const manualMessagesApi = {
-  getManualMessages,
-  getManualMessage,
-  addManualMessage,
-  updateManualMessage,
-  deleteManualMessage,
-  sendManualMessage,
+const messagesApi = {
+  getMessages,
+  getMessage,
+  addMessage,
+  updateMessage,
+  deleteMessage,
+  sendMessage,
 };
 
-export default manualMessagesApi;
+export default messagesApi;

--- a/src/domain/messages/api/messagesApi.ts
+++ b/src/domain/messages/api/messagesApi.ts
@@ -1,12 +1,14 @@
 import { MethodHandlerResponse, MethodHandlerParams } from '../../../api/types';
 import { queryHandler, handleApiConnection } from '../../../api/utils/apiUtils';
 import { MessagesQuery } from '../queries/MessageQueries';
+import { getProjectId } from '../../profile/utils';
 
 async function getMessages(
   params: MethodHandlerParams
 ): Promise<MethodHandlerResponse | null> {
   const response = await queryHandler({
     query: MessagesQuery,
+    variables: { projectId: getProjectId() },
   });
 
   return handleApiConnection(response.data.messages);

--- a/src/domain/messages/choices.ts
+++ b/src/domain/messages/choices.ts
@@ -1,0 +1,23 @@
+export const recipientSelectionOptions = [
+  {
+    id: 'ALL',
+    name: 'messages.fields.recipientSelection.choices.ALL.label',
+  },
+  {
+    id: 'INVITED',
+    name: 'messages.fields.recipientSelection.choices.INVITED.label',
+  },
+  {
+    id: 'ENROLLED',
+    name: 'messages.fields.recipientSelection.choices.ENROLLED.label',
+  },
+  {
+    id: 'ATTENDED',
+    name: 'messages.fields.recipientSelection.choices.ATTENDED.label',
+  },
+  {
+    id: 'SUBSCRIBED_TO_FREE_SPOT_MESSAGE',
+    name:
+      'messages.fields.recipientSelection.choices.SUBSCRIBED_TO_FREE_SPOT_MESSAGE.label',
+  },
+];

--- a/src/domain/messages/create/MessagesCreate.tsx
+++ b/src/domain/messages/create/MessagesCreate.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MessagesCreate = () => {
+  return <>MessagesCreate</>;
+};
+
+export default MessagesCreate;

--- a/src/domain/messages/detail/MessagesDetail.tsx
+++ b/src/domain/messages/detail/MessagesDetail.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MessagesDetail = () => {
+  return <>MessagesDetail</>;
+};
+
+export default MessagesDetail;

--- a/src/domain/messages/edit/MessagesEdit.tsx
+++ b/src/domain/messages/edit/MessagesEdit.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const MessagesEdit = () => {
+  return <>MessagesEdit</>;
+};
+
+export default MessagesEdit;

--- a/src/domain/messages/list/MessagesList.tsx
+++ b/src/domain/messages/list/MessagesList.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {
+  ResourceComponentPropsWithId,
+  useTranslate,
+  TextField,
+  SelectField,
+  useLocale,
+} from 'react-admin';
+
+import KukkuuListPage from '../../../common/components/kukkuuListPage/KukkuuListPage';
+import PublishedField from '../../../common/components/publishedField/PublishedField';
+import { recipientSelectionOptions } from '../choices';
+import styles from './messageList.module.css';
+
+const MessagesList = (props: ResourceComponentPropsWithId) => {
+  const t = useTranslate();
+  const locale = useLocale();
+
+  return (
+    <KukkuuListPage
+      reactAdminProps={props}
+      pageTitle={t('messages.list.title')}
+    >
+      <TextField
+        label={t('messages.fields.subject.label')}
+        source="subject"
+        className={styles.bold}
+      />
+      <SelectField
+        label={t('messages.fields.recipientSelection.label')}
+        source="recipientSelection"
+        choices={recipientSelectionOptions}
+      />
+      <TextField label={t('messages.fields.event.label')} source="event.name" />
+      <TextField
+        label={t('messages.fields.recipientCount.label')}
+        source="recipientCount"
+        className={styles.bold}
+      />
+      <PublishedField
+        label={t('messages.fields.sentAt.label')}
+        source="sentAt"
+        render={(date: Date) =>
+          `${t('messages.fields.sentAt.sent')} ${date.toLocaleString(locale, {
+            year: 'numeric',
+            month: 'numeric',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          })}`
+        }
+        placeholder="messages.fields.sentAt.notSent"
+        className={styles.bold}
+      />
+    </KukkuuListPage>
+  );
+};
+
+export default MessagesList;

--- a/src/domain/messages/list/messageList.module.css
+++ b/src/domain/messages/list/messageList.module.css
@@ -1,0 +1,3 @@
+.bold.bold {
+  font-weight: 800;
+}

--- a/src/domain/messages/queries/MessageQueries.ts
+++ b/src/domain/messages/queries/MessageQueries.ts
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
 
 export const MessagesQuery = gql`
-  query Messages {
-    messages {
+  query Messages($projectId: ID) {
+    messages(projectId: $projectId) {
       edges {
         node {
           id

--- a/src/domain/messages/queries/MessageQueries.ts
+++ b/src/domain/messages/queries/MessageQueries.ts
@@ -1,0 +1,21 @@
+import gql from 'graphql-tag';
+
+export const MessagesQuery = gql`
+  query Messages {
+    messages {
+      edges {
+        node {
+          id
+          subject
+          bodyText
+          recipientSelection
+          recipientCount
+          sentAt
+          event {
+            name
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/domain/occurrences/OccurrenceShow.tsx
+++ b/src/domain/occurrences/OccurrenceShow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactText } from 'react';
 import {
   TextField,
   NumberField,
@@ -101,6 +101,8 @@ const OccurrenceDataGridTitle = ({ occurrenceId }: any) => {
     <>
       {translate('occurrences.fields.children.label')}
       <span className={styles.fakeValue}>
+        {/* eslint-disable-next-line @typescript-eslint/ban-ts-ignore */}
+        {/* @ts-ignore */}
         {record.enrolments?.edges.length || ''}
       </span>
     </>
@@ -166,6 +168,8 @@ const OccurrenceShow = (props: any) => {
           label="occurrences.fields.capacity.label"
         />
         <FunctionField
+          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+          // @ts-ignore
           render={(occurrence: Occurrence) =>
             occurrence.freeSpotNotificationSubscriptions?.edges.length || '0'
           }
@@ -176,12 +180,18 @@ const OccurrenceShow = (props: any) => {
           source="enrolments.edges"
         >
           <Datagrid
-            rowClick={(id: string, basePath: string, record: EnrolmentEdge) =>
-              escape(`/children/${record?.node?.id}/show`)
-            }
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
+            rowClick={(
+              id: ReactText,
+              basePath: string,
+              record: EnrolmentEdge
+            ) => escape(`/children/${record?.node?.id}/show`)}
           >
             <FunctionField
               label="children.fields.name.label"
+              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+              // @ts-ignore
               render={(record: EnrolmentEdge) =>
                 `${record.node?.child.firstName} ${record.node?.child.lastName}`.trim()
               }
@@ -192,6 +202,8 @@ const OccurrenceShow = (props: any) => {
               locales={locale}
             />
             <FunctionField
+              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+              // @ts-ignore
               render={(record: EnrolmentEdge) => getGuardianFullName(record)}
               label="guardian.name"
             />
@@ -201,6 +213,8 @@ const OccurrenceShow = (props: any) => {
               emptyText={translate('guardian.doesNotExist')}
             />
             <FunctionField
+              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+              // @ts-ignore
               render={(record: EnrolmentEdge) => getGuardianLanguage(record)}
               label="events.fields.language.label"
             />

--- a/src/domain/occurrences/inputs.tsx
+++ b/src/domain/occurrences/inputs.tsx
@@ -34,6 +34,8 @@ const OccurrenceCapacityOverrideInput = (
       dataProvider
         // fallback to fetching event data from the API
         .getOne('events', { id: eventId })
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
         .then(({ data }: { data: AdminEvent }) => {
           setEvent(data);
         })

--- a/src/domain/venues/VenueCreate.tsx
+++ b/src/domain/venues/VenueCreate.tsx
@@ -25,6 +25,8 @@ const VenueCreate = (props: any) => {
         aside={<Aside content="venues.create.aside.content" />}
         {...props}
       >
+        {/* eslint-disable-next-line @typescript-eslint/ban-ts-ignore */}
+        {/* @ts-ignore */}
         <SimpleForm variant="outlined" redirect="show" validate={validateVenue}>
           <LanguageTabs
             selectedLanguage={selectedLanguage}
@@ -34,6 +36,8 @@ const VenueCreate = (props: any) => {
             source={`${translation}.name`}
             label="venues.fields.name.label"
             helperText="venues.fields.name.helperText"
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
             validate={selectedLanguage === Language.FI ? required() : null}
             fullWidth
           />

--- a/src/domain/venues/VenueEdit.tsx
+++ b/src/domain/venues/VenueEdit.tsx
@@ -40,6 +40,8 @@ const VenueEdit = (props: any) => {
           <SimpleForm
             variant="outlined"
             redirect="show"
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
             validate={validateVenue}
             toolbar={<VenueEditToolbar />}
           >
@@ -52,6 +54,8 @@ const VenueEdit = (props: any) => {
               source={`${translation}.name`}
               label="venues.fields.name.label"
               helperText="venues.fields.name.helperText"
+              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+              // @ts-ignore
               validate={selectedLanguage === Language.FI ? required() : null}
               fullWidth
             />

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,3 @@
-declare module 'react-admin';
 declare module 'ra-language-finnish';
 declare module 'ra-language-swedish';
 declare module 'ra-language-english';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10680,10 +10680,10 @@ ra-core@^3.6.0, ra-core@^3.7.1:
     recompose "~0.26.0"
     reselect "~3.0.0"
 
-ra-core@^3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/ra-core/-/ra-core-3.8.5.tgz#d39c3bfe6eaa60ad06509e72f63591ac5540039e"
-  integrity sha512-TLZqREIb5B1lZGJDOBmu1+SN+kXgHQSVjp5KWW1/AOvw1N99uCkciOKnWiF8LBkCCvM/zNREFIV/Yh6FTf2Rlw==
+ra-core@^3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/ra-core/-/ra-core-3.9.4.tgz#9151e1f4948e06ed2bbc5efdda207b28ac7f9281"
+  integrity sha512-nDVoOOGzyQ0WCo+tyI0qRO6iQv+ExkAapGfM4Jc/+ARvzmktuRomkrWdBCx5msIxH6w17/n+s6J1OtscohR15w==
   dependencies:
     "@testing-library/react" "^8.0.7"
     classnames "~2.2.5"
@@ -10702,13 +10702,13 @@ ra-data-fakerest@^3.5.5:
   dependencies:
     fakerest "~2.1.0"
 
-ra-i18n-polyglot@^3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/ra-i18n-polyglot/-/ra-i18n-polyglot-3.8.5.tgz#f59a17a757234add7164cbce6fc0a95a925f0065"
-  integrity sha512-ck3g3eZHb5jm0IdKpljSyMvlcH38esjFJBbGxKoGx8sQM3v0T1TtnErI2/s+VGTPFC53n5jqnjKPbfzqV7js/g==
+ra-i18n-polyglot@^3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/ra-i18n-polyglot/-/ra-i18n-polyglot-3.9.4.tgz#5c66609e841acc72aa96417931b48fbe9ae23aed"
+  integrity sha512-2lTDFVvzqnZo/gZXmng2y+NCgcm6hY3W4Sk8zBRP9MwausSi7g3M3E9jepZG4FBZaJYdfKaSrdJjBQesnB5ajg==
   dependencies:
     node-polyglot "^2.2.2"
-    ra-core "^3.8.5"
+    ra-core "^3.9.4"
 
 ra-language-english@^3.6.0:
   version "3.7.1"
@@ -10717,12 +10717,12 @@ ra-language-english@^3.6.0:
   dependencies:
     ra-core "^3.7.1"
 
-ra-language-english@^3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/ra-language-english/-/ra-language-english-3.8.5.tgz#d31f40a7836972fe252c3c98643f246afde24899"
-  integrity sha512-j8O/AMGQaEWzRyQpY1tU3erCozmPdX0AHE+tZM7hNBY34MGmIeqhnySc7o7rBN4gS8vGU1tIejgld8xu0QOMdg==
+ra-language-english@^3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/ra-language-english/-/ra-language-english-3.9.4.tgz#0b76e663cfceee5af277b1c49f5a36c865017a21"
+  integrity sha512-D+HJhvLM60LMKCCghslgcks5hpzcoIbD/sfuG0J2VlOiZMl/TcYtFefpETC/9t0cf9lxuApRCDL5YtSaUoA/CQ==
   dependencies:
-    ra-core "^3.8.5"
+    ra-core "^3.9.4"
 
 ra-language-finnish@^3.6.0:
   version "3.6.0"
@@ -10736,10 +10736,10 @@ ra-language-swedish@^1.0.0:
   resolved "https://registry.yarnpkg.com/ra-language-swedish/-/ra-language-swedish-1.0.0.tgz#6c7a22603b4b19bc17e223339f3e5c458d9e1f75"
   integrity sha512-JwVPB9nP/stPT7R3C6T7NY917GC+cLVNSwYxHxWxUAAfZJ/tjZrJRrkskbM+ELz3EWfFP25YzUmQjCGSzGY1pw==
 
-ra-ui-materialui@^3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/ra-ui-materialui/-/ra-ui-materialui-3.8.5.tgz#3e449befd135c3da7d192dfa629355f0696fae03"
-  integrity sha512-xe0KznjJNy5hJZH+MHLnKPZhp9WvEoORZJv6TpI5tOWPuTRxrT6xrDt3WtwdDJ4SDau5AjUu+4duyjwPsERn9A==
+ra-ui-materialui@^3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/ra-ui-materialui/-/ra-ui-materialui-3.9.4.tgz#c68958492aa25790198d7101117178b034c97da3"
+  integrity sha512-qx6TcVFwVkqqp9tB4tulgVMH2zhpzJTcTvYZlsIEa17jlBNLM9l1iR7LcVbKZDafKacWD14G6+g9R+y/46qDjg==
   dependencies:
     autosuggest-highlight "^3.1.1"
     classnames "~2.2.5"
@@ -10791,10 +10791,10 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-admin@^3.8.5:
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/react-admin/-/react-admin-3.8.5.tgz#37418758455544617a189f3bcc822567f5309750"
-  integrity sha512-jTxZG7E3efVNZ4MGgBnlYm/dw5m63S+sgHcOw+mlh4xTch8KZgwlJxik59Rejtm2K8bjR2yc4p91XZw83IlwUA==
+react-admin@3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/react-admin/-/react-admin-3.9.4.tgz#3738ef8ca7fa68140f0555f177aec2d6f0d12151"
+  integrity sha512-IoORnrjFSwC2I1bM364JgUbg0Moeb8EImuPwKFiNLXWsOTuhsCTLzZW76+7zb+QS5XCvRosGLrkv8mgrXY/HUw==
   dependencies:
     "@material-ui/core" "^4.3.3"
     "@material-ui/icons" "^4.2.1"
@@ -10802,10 +10802,10 @@ react-admin@^3.8.5:
     connected-react-router "^6.5.2"
     final-form "^4.18.5"
     final-form-arrays "^3.0.1"
-    ra-core "^3.8.5"
-    ra-i18n-polyglot "^3.8.5"
-    ra-language-english "^3.8.5"
-    ra-ui-materialui "^3.8.5"
+    ra-core "^3.9.4"
+    ra-i18n-polyglot "^3.9.4"
+    ra-language-english "^3.9.4"
+    ra-ui-materialui "^3.9.4"
     react-final-form "^6.3.3"
     react-final-form-arrays "^3.1.1"
     react-redux "^7.1.0"


### PR DESCRIPTION
## Description

I integrate the list view into the API by implementing the API layer and view layers. I also renamed the model from `ManualMessage` into `Message` to align naming with the backend.

I also updated `react-admin` to version `3.9.0` in this PR in order to get access to types. This application was not type compatible with react-admin. For now I ignored type errors. Ignored errors are an improvement to no errors in my opinion--it allows new code to be typesafe while giving transparency into what current code is not typesafe. Some type errors may be signs of bugs or dangerous behaviour--but these were not as a result of the upgrade, rather the upgrade only made them detectable.

## Context

This change is implemented so that the users have a convenient place to manage messages from.

[KK-592](https://helsinkisolutionoffice.atlassian.net/browse/KK-592)

## How Has This Been Tested?

I've tested this feature manually.

## Manual Testing Instructions for Reviewers

As a logged in admin user in the dashboard

1. Access messages resources from left navigation menu
2. Expect to see a message list (containing a single message)
3. Expect message list to conform to styles in design
4. Expect new message button to take the user to the placeholder create message view
5. Expect clicking on message to take user to the placeholder edit message view

## Screenshots

<img width="1680" alt="Screenshot 2020-10-20 at 14 16 25" src="https://user-images.githubusercontent.com/9090689/96580077-72077e00-12e0-11eb-971d-18396e33d2aa.png">
