### PR TITLE
KK-597 | Add message details view

### DIFF
--- a/src/common/components/kukkuuCardPageLayout/BreadCrumbs.tsx
+++ b/src/common/components/kukkuuCardPageLayout/BreadCrumbs.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ResourceComponentPropsWithId, Link, useTranslate } from 'react-admin';
+import { makeStyles } from '@material-ui/core';
+import Breadcrumbs from '@material-ui/core/Breadcrumbs';
+
+export type CrumbConfig = {
+  resource: string;
+  view: string;
+};
+
+type Crumb = {
+  label: string;
+  link: string;
+};
+
+const useStyles = makeStyles((theme) => ({
+  crumb: {
+    fontSize: theme.typography.body2.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+  },
+}));
+
+type CrumbsProps = {
+  reactAdminProps: ResourceComponentPropsWithId;
+  className: string;
+};
+
+// Currently this Breadcrumb implementation only supports linking back
+// the list view
+const BreadCrumbs = ({ reactAdminProps, className }: CrumbsProps) => {
+  const t = useTranslate();
+  const classes = useStyles();
+
+  const crumb = {
+    label: t(reactAdminProps.options.label) as string,
+    link: `/${reactAdminProps.resource}` as string,
+  };
+
+  return (
+    <Breadcrumbs className={className}>
+      <Link className={classes.crumb} to={crumb.link}>
+        {`< ${crumb.label}`}
+      </Link>
+    </Breadcrumbs>
+  );
+};
+
+export default BreadCrumbs;

--- a/src/common/components/kukkuuCardPageLayout/KukkuuCardPageLayout.tsx
+++ b/src/common/components/kukkuuCardPageLayout/KukkuuCardPageLayout.tsx
@@ -23,7 +23,7 @@ const TitleFromSource = ({ source, reactAdminProps }: TitleFromSourceProps) => {
     reactAdminProps.id
   );
 
-  return <KukkuuPageTitle title={get(data, source)} />;
+  return <KukkuuPageTitle>{get(data, source)}</KukkuuPageTitle>;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -69,7 +69,7 @@ const KukkuuPageLayout = ({
           reactAdminProps={reactAdminProps}
         />
       )}
-      {!pageTitleSource && <KukkuuPageTitle title={pageTitle} />}
+      {!pageTitleSource && <KukkuuPageTitle>{pageTitle}</KukkuuPageTitle>}
       <Grid container direction="column" xs={6} item={true}>
         {children}
       </Grid>

--- a/src/common/components/kukkuuCardPageLayout/KukkuuCardPageLayout.tsx
+++ b/src/common/components/kukkuuCardPageLayout/KukkuuCardPageLayout.tsx
@@ -1,0 +1,67 @@
+import React, { ReactElement } from 'react';
+import {
+  EditProps,
+  ResourceComponentPropsWithId,
+  useGetOne,
+} from 'react-admin';
+import { Grid, makeStyles } from '@material-ui/core';
+import get from 'lodash/get';
+
+import KukkuuPageTitle from '../kukkuuPageTitle/KukkuuPageTitle';
+
+type TitleFromSourceProps = {
+  source: string;
+  reactAdminProps: ResourceComponentPropsWithId;
+};
+
+const TitleFromSource = ({ source, reactAdminProps }: TitleFromSourceProps) => {
+  const { data } = useGetOne(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    reactAdminProps.resource,
+    reactAdminProps.id
+  );
+
+  return <KukkuuPageTitle title={get(data, source)} />;
+};
+
+const useStyles = makeStyles({
+  pageWrapper: {
+    '& .MuiToolbar-root': {
+      paddingTop: 0,
+    },
+  },
+});
+
+type Props = {
+  reactAdminProps: EditProps;
+  children: ReactElement;
+  pageTitle?: string;
+  pageTitleSource?: string;
+};
+
+const KukkuuPageLayout = ({
+  children,
+  reactAdminProps,
+  pageTitleSource,
+  pageTitle,
+}: Props) => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.pageWrapper}>
+      {pageTitleSource && (
+        <TitleFromSource
+          source={pageTitleSource}
+          reactAdminProps={reactAdminProps}
+        />
+      )}
+      {!pageTitleSource && <KukkuuPageTitle title={pageTitle} />}
+      <Grid container direction="column" xs={6} item={true}>
+        {children}
+      </Grid>
+    </div>
+  );
+};
+
+export default KukkuuPageLayout;

--- a/src/common/components/kukkuuCardPageLayout/KukkuuCardPageLayout.tsx
+++ b/src/common/components/kukkuuCardPageLayout/KukkuuCardPageLayout.tsx
@@ -8,6 +8,7 @@ import { Grid, makeStyles } from '@material-ui/core';
 import get from 'lodash/get';
 
 import KukkuuPageTitle from '../kukkuuPageTitle/KukkuuPageTitle';
+import BreadCrumbs, { CrumbConfig } from './BreadCrumbs';
 
 type TitleFromSourceProps = {
   source: string;
@@ -25,19 +26,24 @@ const TitleFromSource = ({ source, reactAdminProps }: TitleFromSourceProps) => {
   return <KukkuuPageTitle title={get(data, source)} />;
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   pageWrapper: {
     '& .MuiToolbar-root': {
       paddingTop: 0,
     },
   },
-});
+  breadCrumbs: {
+    position: 'absolute',
+    top: theme.spacing(9),
+  },
+}));
 
 type Props = {
   reactAdminProps: EditProps;
   children: ReactElement;
   pageTitle?: string;
   pageTitleSource?: string;
+  breadcrumbs?: boolean | CrumbConfig[];
 };
 
 const KukkuuPageLayout = ({
@@ -45,11 +51,18 @@ const KukkuuPageLayout = ({
   reactAdminProps,
   pageTitleSource,
   pageTitle,
+  breadcrumbs,
 }: Props) => {
   const classes = useStyles();
 
   return (
     <div className={classes.pageWrapper}>
+      {breadcrumbs && (
+        <BreadCrumbs
+          reactAdminProps={reactAdminProps}
+          className={classes.breadCrumbs}
+        />
+      )}
       {pageTitleSource && (
         <TitleFromSource
           source={pageTitleSource}

--- a/src/common/components/kukkuuCreatePage/KukkuuCreatePage.tsx
+++ b/src/common/components/kukkuuCreatePage/KukkuuCreatePage.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Create, CreateProps } from 'react-admin';
-import { CardHeader, Grid } from '@material-ui/core';
+
+import KukkuuPageLayout from '../kukkuuCardPageLayout/KukkuuCardPageLayout';
 
 type Props = {
   pageTitle: string;
@@ -10,12 +11,15 @@ type Props = {
 
 const KukkuuCreatePage = ({ children, pageTitle, reactAdminProps }: Props) => {
   return (
-    <>
-      <CardHeader title={pageTitle} />
-      <Grid container direction="column" xs={6} item={true}>
-        <Create {...reactAdminProps}>{children}</Create>
-      </Grid>
-    </>
+    <KukkuuPageLayout pageTitle={pageTitle} reactAdminProps={reactAdminProps}>
+      <Create
+        {...reactAdminProps}
+        // Use empty actions so that no extra margin is applied
+        actions={<></>}
+      >
+        {children}
+      </Create>
+    </KukkuuPageLayout>
   );
 };
 

--- a/src/common/components/kukkuuDetailPage/KukkuuDetailPage.tsx
+++ b/src/common/components/kukkuuDetailPage/KukkuuDetailPage.tsx
@@ -16,7 +16,11 @@ const KukkuuDetailPage = ({
   reactAdminProps: { hasShow, ...props },
 }: Props) => {
   return (
-    <KukkuuPageLayout pageTitleSource={pageTitleSource} reactAdminProps={props}>
+    <KukkuuPageLayout
+      pageTitleSource={pageTitleSource}
+      reactAdminProps={props}
+      breadcrumbs
+    >
       <KukkuuShow {...props}>{children}</KukkuuShow>
     </KukkuuPageLayout>
   );

--- a/src/common/components/kukkuuDetailPage/KukkuuDetailPage.tsx
+++ b/src/common/components/kukkuuDetailPage/KukkuuDetailPage.tsx
@@ -1,0 +1,25 @@
+import React, { ReactElement } from 'react';
+import { ResourceComponentPropsWithId } from 'react-admin';
+
+import KukkuuShow from '../kukkuuShow/KukkuuShow';
+import KukkuuPageLayout from '../kukkuuCardPageLayout/KukkuuCardPageLayout';
+
+type Props = {
+  children: ReactElement;
+  reactAdminProps: ResourceComponentPropsWithId;
+  pageTitleSource: string;
+};
+
+const KukkuuDetailPage = ({
+  children,
+  pageTitleSource,
+  reactAdminProps: { hasShow, ...props },
+}: Props) => {
+  return (
+    <KukkuuPageLayout pageTitleSource={pageTitleSource} reactAdminProps={props}>
+      <KukkuuShow {...props}>{children}</KukkuuShow>
+    </KukkuuPageLayout>
+  );
+};
+
+export default KukkuuDetailPage;

--- a/src/common/components/kukkuuEditPage/KukkuuEditPage.tsx
+++ b/src/common/components/kukkuuEditPage/KukkuuEditPage.tsx
@@ -1,32 +1,30 @@
 import React, { ReactElement } from 'react';
-import { EditProps, useGetOne } from 'react-admin';
-import { CardHeader, Grid } from '@material-ui/core';
+import { ResourceComponentPropsWithId } from 'react-admin';
 
+import KukkuuPageLayout from '../kukkuuCardPageLayout/KukkuuCardPageLayout';
 import KukkuuEdit from '../../../common/components/kukkuuEdit/KukkuuEdit';
 
 type Props = {
-  reactAdminProps: EditProps;
+  reactAdminProps: ResourceComponentPropsWithId;
   children: ReactElement;
+  pageTitleSource: string;
 };
 
-const EventEdit = ({ children, reactAdminProps }: Props) => {
-  const { data } = useGetOne(
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    reactAdminProps.resource,
-    reactAdminProps.id
-  );
-
+const KukkuuEditPage = ({
+  children,
+  reactAdminProps,
+  pageTitleSource,
+}: Props) => {
   return (
-    <>
-      <CardHeader title={data?.subject || ''} />
-      <Grid container direction="column" xs={6} item={true}>
-        <KukkuuEdit undoable={false} actions={<></>} {...reactAdminProps}>
-          {children}
-        </KukkuuEdit>
-      </Grid>
-    </>
+    <KukkuuPageLayout
+      pageTitleSource={pageTitleSource}
+      reactAdminProps={reactAdminProps}
+    >
+      <KukkuuEdit undoable={false} actions={<></>} {...reactAdminProps}>
+        {children}
+      </KukkuuEdit>
+    </KukkuuPageLayout>
   );
 };
 
-export default EventEdit;
+export default KukkuuEditPage;

--- a/src/common/components/kukkuuListPage/KukkuuListPage.tsx
+++ b/src/common/components/kukkuuListPage/KukkuuListPage.tsx
@@ -25,7 +25,7 @@ const KukkuuListPage = ({ pageTitle, children, reactAdminProps }: Props) => {
 
   return (
     <>
-      <KukkuuPageTitle title={pageTitle} />
+      <KukkuuPageTitle>{pageTitle}</KukkuuPageTitle>
       <KukkuuList
         bulkActionButtons={false}
         pagination={false}

--- a/src/common/components/kukkuuListPage/KukkuuListPage.tsx
+++ b/src/common/components/kukkuuListPage/KukkuuListPage.tsx
@@ -1,8 +1,18 @@
 import React, { ReactNode } from 'react';
 import { Datagrid, ResourceComponentPropsWithId } from 'react-admin';
-import { CardHeader } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core';
 
 import KukkuuList from '../kukkuuList/KukkuuList';
+import KukkuuPageTitle from '../kukkuuPageTitle/KukkuuPageTitle';
+
+const useStyles = makeStyles({
+  list: {
+    '& > .MuiToolbar-root': {
+      // Use slightly less padding between title and actions
+      marginTop: '-24px',
+    },
+  },
+});
 
 type Props = {
   pageTitle: string;
@@ -11,14 +21,17 @@ type Props = {
 };
 
 const KukkuuListPage = ({ pageTitle, children, reactAdminProps }: Props) => {
+  const classes = useStyles();
+
   return (
     <>
-      <CardHeader title={pageTitle} />
+      <KukkuuPageTitle title={pageTitle} />
       <KukkuuList
         bulkActionButtons={false}
         pagination={false}
         exporter={false}
         {...reactAdminProps}
+        className={classes.list}
       >
         <Datagrid rowClick="show">{children}</Datagrid>
       </KukkuuList>

--- a/src/common/components/kukkuuPageTitle/KukkuuPageTitle.tsx
+++ b/src/common/components/kukkuuPageTitle/KukkuuPageTitle.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { CardHeader, CardHeaderProps, makeStyles } from '@material-ui/core';
+
+const useTitleStyles = makeStyles({
+  title: {
+    paddingLeft: 0,
+    paddingTop: '2rem',
+    '& .MuiCardHeader-title': {
+      fontWeight: 600,
+    },
+  },
+});
+
+const KukkuuPageTitle = (props: CardHeaderProps) => {
+  const classes = useTitleStyles();
+
+  return <CardHeader {...props} className={classes.title} />;
+};
+
+export default KukkuuPageTitle;

--- a/src/common/components/kukkuuPageTitle/KukkuuPageTitle.tsx
+++ b/src/common/components/kukkuuPageTitle/KukkuuPageTitle.tsx
@@ -1,20 +1,25 @@
 import React from 'react';
-import { CardHeader, CardHeaderProps, makeStyles } from '@material-ui/core';
+import { makeStyles, TypographyProps, Typography } from '@material-ui/core';
 
 const useTitleStyles = makeStyles((theme) => ({
   title: {
-    paddingLeft: 0,
     paddingTop: theme.spacing(7),
-    '& .MuiCardHeader-title': {
-      fontWeight: theme.typography.fontWeightBold,
-    },
+    paddingBottom: theme.spacing(1.5),
+    fontWeight: theme.typography.fontWeightBold,
   },
 }));
 
-const KukkuuPageTitle = (props: CardHeaderProps) => {
+const KukkuuPageTitle = (props: TypographyProps<'h1'>) => {
   const classes = useTitleStyles();
 
-  return <CardHeader {...props} className={classes.title} />;
+  return (
+    <Typography
+      component="h1"
+      variant="h5"
+      {...props}
+      className={classes.title}
+    />
+  );
 };
 
 export default KukkuuPageTitle;

--- a/src/common/components/kukkuuPageTitle/KukkuuPageTitle.tsx
+++ b/src/common/components/kukkuuPageTitle/KukkuuPageTitle.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { CardHeader, CardHeaderProps, makeStyles } from '@material-ui/core';
 
-const useTitleStyles = makeStyles({
+const useTitleStyles = makeStyles((theme) => ({
   title: {
     paddingLeft: 0,
-    paddingTop: '2rem',
+    paddingTop: theme.spacing(7),
     '& .MuiCardHeader-title': {
-      fontWeight: 600,
+      fontWeight: theme.typography.fontWeightBold,
     },
   },
-});
+}));
 
 const KukkuuPageTitle = (props: CardHeaderProps) => {
   const classes = useTitleStyles();

--- a/src/common/components/publishedField/PublishedField.tsx
+++ b/src/common/components/publishedField/PublishedField.tsx
@@ -1,12 +1,12 @@
 import React, { ReactElement, ReactNode } from 'react';
 import Typography from '@material-ui/core/Typography';
-import { useTranslate, useLocale } from 'react-admin';
+import { useLocale } from 'react-admin';
 import get from 'lodash/get';
 
 type Props = {
   label: string;
   record?: unknown;
-  placeholder?: string | null;
+  emptyText?: string | null;
   source: string;
   render?: (date: Date) => ReactNode;
   className?: string;
@@ -14,12 +14,11 @@ type Props = {
 
 const PublishedField = ({
   record,
-  placeholder = null,
+  emptyText = null,
   source,
   render,
   className,
 }: Props): ReactElement | null => {
-  const translate = useTranslate();
   const locale = useLocale();
 
   if (!record) return null;
@@ -31,7 +30,7 @@ const PublishedField = ({
     <Typography variant="body2" className={className}>
       {sourceData && render && render(date)}
       {sourceData && !render && date.toLocaleString(locale)}
-      {!sourceData && placeholder && translate(placeholder)}
+      {!sourceData && emptyText}
     </Typography>
   );
 };

--- a/src/domain/messages/detail/MessagesDetail.tsx
+++ b/src/domain/messages/detail/MessagesDetail.tsx
@@ -1,7 +1,68 @@
 import React from 'react';
+import {
+  TextField,
+  SelectField,
+  SimpleShowLayout,
+  ResourceComponentPropsWithId,
+  useTranslate,
+} from 'react-admin';
+import { makeStyles } from '@material-ui/core';
 
-const MessagesDetail = () => {
-  return <>MessagesDetail</>;
+import KukkuuDetailPage from '../../../common/components/kukkuuDetailPage/KukkuuDetailPage';
+import useLanguageTabs from '../hooks/useLanguageTabs';
+import { recipientSelectionChoices } from '../choices';
+
+const useStyles = makeStyles({
+  inline: {
+    display: 'inline-flex',
+    width: '50%',
+    '& > *': {
+      width: '100%',
+    },
+  },
+  showLayout: {
+    '& > .ra-field': {
+      marginBottom: '1rem',
+    },
+  },
+});
+
+const MessagesDetail = ({
+  hasShow,
+  ...props
+}: ResourceComponentPropsWithId) => {
+  const classes = useStyles();
+  const [languageTabsComponent, translatableField] = useLanguageTabs();
+  const t = useTranslate();
+
+  return (
+    <KukkuuDetailPage pageTitleSource="subject" reactAdminProps={props}>
+      <SimpleShowLayout className={classes.showLayout}>
+        {languageTabsComponent}
+        <SelectField
+          source="recipientSelection"
+          label="messages.fields.recipientSelection.label"
+          choices={recipientSelectionChoices}
+          className={classes.inline}
+        />
+        <TextField
+          source="event.name"
+          label="messages.fields.event.label"
+          className={classes.inline}
+          emptyText={t('messages.fields.event.all')}
+        />
+        <TextField
+          source={translatableField('subject')}
+          label="messages.fields.subject.label2"
+        />
+        <TextField
+          component="pre"
+          source={translatableField('bodyText')}
+          label="messages.fields.bodyText.label"
+        />
+      </SimpleShowLayout>
+    </KukkuuDetailPage>
+  );
 };
 
 export default MessagesDetail;

--- a/src/domain/messages/edit/MessagesEdit.tsx
+++ b/src/domain/messages/edit/MessagesEdit.tsx
@@ -6,7 +6,7 @@ import MessageForm from '../form/MessageForm';
 
 const MessagesEdit = (props: ResourceComponentProps) => {
   return (
-    <KukkuuEditPage reactAdminProps={props}>
+    <KukkuuEditPage pageTitleSource="subject" reactAdminProps={props}>
       <MessageForm />
     </KukkuuEditPage>
   );

--- a/src/domain/messages/form/MessageForm.tsx
+++ b/src/domain/messages/form/MessageForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactElement } from 'react';
+import React from 'react';
 import {
   TextInput,
   SimpleForm,
@@ -6,9 +6,8 @@ import {
   SimpleFormProps,
 } from 'react-admin';
 
-import LanguageTabs from '../../../common/components/languageTab/LanguageTabs';
-import { Language } from '../../../api/generatedTypes/globalTypes';
 import EventSelect from '../../events/eventSelect/EventSelect';
+import useLanguageTabs from '../hooks/useLanguageTabs';
 import {
   validateRecipientSelection,
   validateSubject,
@@ -16,25 +15,6 @@ import {
 } from '../validations';
 import { recipientSelectionChoices } from '../choices';
 import styles from './messageForm.module.css';
-
-function useLanguageTabs(): [
-  ReactElement,
-  (fieldName: string) => string,
-  Language,
-  (language: Language) => void
-] {
-  const [selectedLanguage, selectLanguage] = useState(Language.FI);
-  const tField = (fieldName: string) =>
-    `translations.${selectedLanguage}.${fieldName}`;
-  const component = (
-    <LanguageTabs
-      selectedLanguage={selectedLanguage}
-      onSelect={selectLanguage}
-    />
-  );
-
-  return [component, tField, selectedLanguage, selectLanguage];
-}
 
 type Props = Omit<SimpleFormProps, 'children'>;
 

--- a/src/domain/messages/hooks/useLanguageTabs.tsx
+++ b/src/domain/messages/hooks/useLanguageTabs.tsx
@@ -1,0 +1,25 @@
+import React, { useState, ReactElement } from 'react';
+
+import LanguageTabs from '../../../common/components/languageTab/LanguageTabs';
+import { Language } from '../../../api/generatedTypes/globalTypes';
+
+function useLanguageTabs(): [
+  ReactElement,
+  (fieldName: string) => string,
+  Language,
+  (language: Language) => void
+] {
+  const [selectedLanguage, selectLanguage] = useState(Language.FI);
+  const tField = (fieldName: string) =>
+    `translations.${selectedLanguage}.${fieldName}`;
+  const component = (
+    <LanguageTabs
+      selectedLanguage={selectedLanguage}
+      onSelect={selectLanguage}
+    />
+  );
+
+  return [component, tField, selectedLanguage, selectLanguage];
+}
+
+export default useLanguageTabs;

--- a/src/domain/messages/list/MessagesList.tsx
+++ b/src/domain/messages/list/MessagesList.tsx
@@ -53,7 +53,7 @@ const MessagesList = (props: ResourceComponentPropsWithId) => {
             minute: '2-digit',
           })}`
         }
-        placeholder="messages.fields.sentAt.notSent"
+        emptyText={t('messages.fields.sentAt.notSent')}
         className={styles.bold}
       />
     </KukkuuListPage>

--- a/src/domain/messages/list/MessagesList.tsx
+++ b/src/domain/messages/list/MessagesList.tsx
@@ -31,7 +31,11 @@ const MessagesList = (props: ResourceComponentPropsWithId) => {
         source="recipientSelection"
         choices={recipientSelectionChoices}
       />
-      <TextField label={t('messages.fields.event.label')} source="event.name" />
+      <TextField
+        label={t('messages.fields.event.label')}
+        source="event.name"
+        emptyText={t('messages.fields.event.all')}
+      />
       <TextField
         label={t('messages.fields.recipientCount.label')}
         source="recipientCount"


### PR DESCRIPTION
## Description

This PR adds the details view for messages. It adds the `KukkuuCardPageLayout` abstraction, which supports a very basic breadcrumbs setup.

This PR also adjusts the UI in a few minor ways
- The field for event in list view would return empty with no event when the label should be "All Events" if no single event is specified
- Fixes confusing naming for prop `placeholder` of `PublishedField`
- Changes the page title from a span element into a H1 element

## Context

This change is done in order to support manual message management through this admin UI.

[KK-597](https://helsinkisolutionoffice.atlassian.net/browse/KK-597)

## How Has This Been Tested?

This has been tested manually.

## Manual Testing Instructions for Reviewers

As a logged in admin user

1. Access messages view from the left navigation menu
1. Select message from list by clicking
1. Expect to be taken into the view visible in the screenshot
1. Expect edit button to take you into editing view
1. Expect there to be a single breadcrumb back into message list view
1. Expect to be able to browse message content in all three languages

## Screenshots

<img width="1680" alt="Screenshot 2020-10-22 at 13 14 17" src="https://user-images.githubusercontent.com/9090689/96858130-88404600-1468-11eb-8e5d-571e6608e97e.png">