### PR TITLE
KK-596 | Make delete button work

### DIFF
--- a/src/api/generatedTypes/DeleteMessage.ts
+++ b/src/api/generatedTypes/DeleteMessage.ts
@@ -1,0 +1,22 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { DeleteMessageMutationInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: DeleteMessage
+// ====================================================
+
+export interface DeleteMessage_deleteMessage {
+  clientMutationId: string | null;
+}
+
+export interface DeleteMessage {
+  deleteMessage: DeleteMessage_deleteMessage | null;
+}
+
+export interface DeleteMessageVariables {
+  input: DeleteMessageMutationInput;
+}

--- a/src/api/generatedTypes/Message.ts
+++ b/src/api/generatedTypes/Message.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { RecipientSelectionEnum } from "./globalTypes";
+import { RecipientSelectionEnum, LanguageTranslationLanguageCode } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Message
@@ -11,6 +11,12 @@ import { RecipientSelectionEnum } from "./globalTypes";
 
 export interface Message_message_event {
   name: string | null;
+}
+
+export interface Message_message_translations {
+  languageCode: LanguageTranslationLanguageCode;
+  subject: string;
+  bodyText: string;
 }
 
 export interface Message_message {
@@ -24,6 +30,7 @@ export interface Message_message {
   recipientCount: number | null;
   sentAt: any | null;
   event: Message_message_event | null;
+  translations: Message_message_translations[];
 }
 
 export interface Message {

--- a/src/api/generatedTypes/MessageFragment.ts
+++ b/src/api/generatedTypes/MessageFragment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { RecipientSelectionEnum } from "./globalTypes";
+import { RecipientSelectionEnum, LanguageTranslationLanguageCode } from "./globalTypes";
 
 // ====================================================
 // GraphQL fragment: MessageFragment
@@ -11,6 +11,12 @@ import { RecipientSelectionEnum } from "./globalTypes";
 
 export interface MessageFragment_event {
   name: string | null;
+}
+
+export interface MessageFragment_translations {
+  languageCode: LanguageTranslationLanguageCode;
+  subject: string;
+  bodyText: string;
 }
 
 export interface MessageFragment {
@@ -24,4 +30,5 @@ export interface MessageFragment {
   recipientCount: number | null;
   sentAt: any | null;
   event: MessageFragment_event | null;
+  translations: MessageFragment_translations[];
 }

--- a/src/api/generatedTypes/Messages.ts
+++ b/src/api/generatedTypes/Messages.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { RecipientSelectionEnum } from "./globalTypes";
+import { RecipientSelectionEnum, LanguageTranslationLanguageCode } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: Messages
@@ -11,6 +11,12 @@ import { RecipientSelectionEnum } from "./globalTypes";
 
 export interface Messages_messages_edges_node_event {
   name: string | null;
+}
+
+export interface Messages_messages_edges_node_translations {
+  languageCode: LanguageTranslationLanguageCode;
+  subject: string;
+  bodyText: string;
 }
 
 export interface Messages_messages_edges_node {
@@ -24,6 +30,7 @@ export interface Messages_messages_edges_node {
   recipientCount: number | null;
   sentAt: any | null;
   event: Messages_messages_edges_node_event | null;
+  translations: Messages_messages_edges_node_translations[];
 }
 
 export interface Messages_messages_edges {

--- a/src/api/generatedTypes/globalTypes.ts
+++ b/src/api/generatedTypes/globalTypes.ts
@@ -22,6 +22,15 @@ export enum Language {
   SV = "SV",
 }
 
+/**
+ * An enumeration.
+ */
+export enum LanguageTranslationLanguageCode {
+  EN = "EN",
+  FI = "FI",
+  SV = "SV",
+}
+
 export enum RecipientSelectionEnum {
   ALL = "ALL",
   ATTENDED = "ATTENDED",
@@ -65,6 +74,11 @@ export interface AddVenueMutationInput {
 }
 
 export interface DeleteEventMutationInput {
+  id: string;
+  clientMutationId?: string | null;
+}
+
+export interface DeleteMessageMutationInput {
   id: string;
   clientMutationId?: string | null;
 }

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -329,5 +329,10 @@
       },
       "title": "Venues"
     }
+  },
+  "ra": {
+    "message": {
+      "delete_title": "Delete"
+    }
   }
 }

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -329,5 +329,10 @@
       },
       "title": "Tapahtumapaikat"
     }
+  },
+  "ra": {
+    "message": {
+      "delete_title": "Poista"
+    }
   }
 }

--- a/src/common/translation/i18nProvider.tsx
+++ b/src/common/translation/i18nProvider.tsx
@@ -8,10 +8,28 @@ import fiDomainMessages from './fi.json';
 import svDomainMessages from './sv.json';
 import enDomainMessages from './en.json';
 
+// By default the delete confirmation modal title contains the ID of the
+// resource that is being deleted. As a quick fix we are replacing the
+// translation string with a more simple one.
+function hideIdFromDeleteConfirmation(domainMessages: any, raMessages: any) {
+  return {
+    ...raMessages,
+    ...domainMessages,
+    ra: {
+      ...raMessages.ra,
+      message: {
+        ...raMessages.ra.message,
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        delete_title: domainMessages.ra.message.delete_title,
+      },
+    },
+  };
+}
+
 const allMessages: { [index: string]: TranslationMessages } = {
-  fi: { ...fiMessages, ...fiDomainMessages },
-  sv: { ...svMessages, ...svDomainMessages },
-  en: { ...enMessages, ...enDomainMessages },
+  fi: hideIdFromDeleteConfirmation(fiDomainMessages, fiMessages),
+  sv: hideIdFromDeleteConfirmation(svDomainMessages, svMessages),
+  en: hideIdFromDeleteConfirmation(enDomainMessages, enMessages),
 };
 
 const i18nProvider = polyglotI18nProvider(

--- a/src/common/translation/sv.json
+++ b/src/common/translation/sv.json
@@ -185,5 +185,10 @@
       "contactEmail": "kulttuurin.kummilapset@hel.fi",
       "backToLoginPage": "Back to login page"
     }
+  },
+  "ra": {
+    "message": {
+      "delete_title": "Delete"
+    }
   }
 }

--- a/src/domain/messages/api/messagesApi.ts
+++ b/src/domain/messages/api/messagesApi.ts
@@ -1,6 +1,3 @@
-import { ApolloQueryResult } from 'apollo-client';
-
-import { Message } from '../../../api/generatedTypes/Message';
 import { MethodHandlerResponse, MethodHandlerParams } from '../../../api/types';
 import {
   queryHandler,
@@ -13,6 +10,7 @@ import { messagesQuery, messageQuery } from '../queries/MessageQueries';
 import {
   addMessageMutation,
   updateMessageMutation,
+  deleteMessageMutation,
 } from '../mutations/MessageMutations';
 import { getProjectId } from '../../profile/utils';
 
@@ -30,7 +28,7 @@ async function getMessages(
 async function getMessage(
   params: MethodHandlerParams
 ): Promise<MethodHandlerResponse | null> {
-  const response: ApolloQueryResult<Message> = await queryHandler({
+  const response = await queryHandler({
     query: messageQuery,
     variables: { id: params.id },
   });
@@ -100,10 +98,16 @@ async function updateMessage(
 
   return handleApiNode(response.data?.updateMessage.message);
 }
-function deleteMessage(
+
+async function deleteMessage(
   params: MethodHandlerParams
 ): Promise<MethodHandlerResponse | null> {
-  return Promise.resolve(null);
+  await mutationHandler({
+    mutation: deleteMessageMutation,
+    variables: { input: { id: params.id } },
+  });
+
+  return { data: { id: params.id } };
 }
 function sendMessage(
   params: MethodHandlerParams

--- a/src/domain/messages/mutations/MessageMutations.ts
+++ b/src/domain/messages/mutations/MessageMutations.ts
@@ -19,3 +19,11 @@ export const updateMessageMutation = gql`
     }
   }
 `;
+
+export const deleteMessageMutation = gql`
+  mutation DeleteMessage($input: DeleteMessageMutationInput!) {
+    deleteMessage(input: $input) {
+      clientMutationId
+    }
+  }
+`;


### PR DESCRIPTION
## Description

Implements the delete call of the messages API. I also adjusted react-admin translations in order to hide the ID of the deleted resource from the modal title.

## Context

By adding the delete call to the API we make the delete button in the message view work--it now deleted the message and should redirect users correctly.

[KK-596](https://helsinkisolutionoffice.atlassian.net/browse/KK-596)

## How Has This Been Tested?

This has been tested manually by trying out the delete button.

## Manual Testing Instructions for Reviewers

As a logged in admin user

1. Access message list view
1. Create a new message
1. Select the created message by clicking it from the list
1. Access edit view by pressing the edit button. If details view is not yet implemented, access the view by removing `/ show` from the url.
1. Press delete button
1. Expect deleting to work: no errors
1. Expect to be taken into the list view

## Screenshots

<!-- Add screenshots if appropriate -->