### PR TITLE
Do not send permission errors to Sentry

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { setContext } from 'apollo-link-context';
@@ -5,6 +6,7 @@ import { onError } from 'apollo-link-error';
 import { ApolloLink } from 'apollo-link';
 import { createUploadLink } from 'apollo-upload-client';
 import * as Sentry from '@sentry/browser';
+import { OperationDefinitionNode } from 'graphql';
 
 import i18nProvider from '../common/translation/i18nProvider';
 
@@ -15,25 +17,73 @@ const uploadLink = createUploadLink({
   },
 });
 
-const errorLink = onError(({ graphQLErrors, networkError }) => {
+const stringify = (value: unknown) => JSON.stringify(value, null, 2);
+
+const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
   if (graphQLErrors) {
     graphQLErrors.forEach((graphQLError) => {
       // eslint-disable-next-line max-len
       const errorMessage = `[GraphQL error]: Message: ${graphQLError.message}, Location: ${graphQLError.locations}, Path: ${graphQLError.path}`;
       if (process.env.NODE_ENV === 'development') {
-        // eslint-disable-next-line no-console
         console.error(errorMessage);
       }
 
-      // If JWT is expired it means that we want people to log in again. We don't need to log this to sentry.
       if (
         graphQLError.message ===
         'Invalid Authorization header. JWT has expired.'
       ) {
-        // eslint-disable-next-line no-console
+        // If JWT is expired it means that we want people to log in again. We don't need to log this to sentry.
         console.error('JWT expired');
+      } else if (graphQLError?.extensions?.code === 'PERMISSION_DENIED_ERROR') {
+        // Most permission errors happen when user authentication
+        // expires or when the user accesses the application before
+        // authentication. Due to how react-admin's optimistic nature,
+        // these errors can happen with practically any call. Permission
+        // errors end up creating a lot of noise in Sentry, so it's
+        // worth it to ignore them in our opinion even with the chance
+        // that we miss a few edge cases.
+        console.error('Permissions denied');
       } else {
-        Sentry.captureException(graphQLError);
+        const {
+          originalError,
+          extensions,
+          locations,
+          message,
+          path,
+        } = graphQLError;
+
+        const operationName = operation.operationName;
+        const operationKind = operation.query.definitions.find(
+          (definition): definition is OperationDefinitionNode =>
+            definition.kind === 'OperationDefinition'
+        )?.operation;
+
+        Sentry.withScope((scope) => {
+          scope.setLevel(Sentry.Severity.Error);
+
+          scope.setTag('type', 'GraphQL Error');
+          scope.setTag('operation.name', operationName);
+          if (operationKind) {
+            scope.setTag('operation.kind', operationKind);
+          }
+
+          scope.setContext('GraphQL Error', {
+            extensions: stringify(extensions),
+            locations: stringify(locations),
+            path: stringify(path),
+          });
+          scope.setContext('Operation', {
+            name: operationName,
+            kind: operationKind,
+          });
+
+          if (originalError) {
+            scope.setExtra('message', message);
+            Sentry.captureException(originalError);
+          } else {
+            Sentry.captureMessage(message);
+          }
+        });
       }
     });
   }


### PR DESCRIPTION
## Description

In this PR I stop permission related errors from being sent into Sentry. I also improve the way in which GraphQL errors are sent into Sentry. Previously they were sent using the `captureException` method, but that methods officially only supports `Error` objects. Instead I am now using the `captureMessage` method, and pass the other additional information using Sentry's context.

## Context

Kukkuu admin's Sentry is filled with permission related errors that happen when authentication expires or when the user has not yet authenticated at all. In these instances a permission error is an expected conclusion.

## How Has This Been Tested?

I've logged test events into Sentry and checked that the additional context is communicated as expected as well as that permission related errors are now ignores.

## Manual Testing Instructions for Reviewers

I logged test events into our "production" Sentry, which is not ideal and which is why I don't have a test routine I could recommend.
