### PR TITLE
KK-610 | Add support for occurrence filtering in messages

### DIFF
--- a/browser-tests/utils/valueUtils.ts
+++ b/browser-tests/utils/valueUtils.ts
@@ -3,6 +3,7 @@ export const includesHeaders = (element: Element, id: number) => {
     'Nimi',
     'Vastaanottajat',
     'Tapahtuma',
+    'Esiintymät',
     'Vastaanottajia',
     'Julkaisu',
   ];

--- a/src/api/dataProvider.ts
+++ b/src/api/dataProvider.ts
@@ -26,6 +26,7 @@ import {
   updateOccurrence,
   deleteOccurrence,
   setEnrolmentAttendance,
+  getOccurrencesManyReference,
 } from '../domain/occurrences/api/OccurrenceApi';
 import { getChild, getChildren } from '../domain/children/api/ChildApi';
 import { getMyAdminProfile } from '../domain/profile/api';
@@ -51,12 +52,13 @@ const METHOD_HANDLERS: MethodHandlers = {
     PUBLISH: publishEvent,
   },
   occurrences: {
-    LIST: getEvents,
+    LIST: getOccurrences,
     ONE: getOccurrence,
+    MANY: getOccurrences,
     CREATE: addOccurrence,
     UPDATE: updateOccurrence,
     DELETE: deleteOccurrence,
-    MANY_REFERENCE: getOccurrences,
+    MANY_REFERENCE: getOccurrencesManyReference,
   },
   children: {
     LIST: getChildren,

--- a/src/api/generatedTypes/Message.ts
+++ b/src/api/generatedTypes/Message.ts
@@ -23,6 +23,27 @@ export interface Message_message_translations {
   bodyText: string;
 }
 
+export interface Message_message_occurrences_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+}
+
+export interface Message_message_occurrences_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: Message_message_occurrences_edges_node | null;
+}
+
+export interface Message_message_occurrences {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (Message_message_occurrences_edges | null)[];
+}
+
 export interface Message_message {
   /**
    * The ID of the object.
@@ -35,6 +56,7 @@ export interface Message_message {
   sentAt: any | null;
   event: Message_message_event | null;
   translations: Message_message_translations[];
+  occurrences: Message_message_occurrences;
 }
 
 export interface Message {

--- a/src/api/generatedTypes/Message.ts
+++ b/src/api/generatedTypes/Message.ts
@@ -28,6 +28,7 @@ export interface Message_message_occurrences_edges_node {
    * The ID of the object.
    */
   id: string;
+  time: any;
 }
 
 export interface Message_message_occurrences_edges {

--- a/src/api/generatedTypes/MessageFragment.ts
+++ b/src/api/generatedTypes/MessageFragment.ts
@@ -28,6 +28,7 @@ export interface MessageFragment_occurrences_edges_node {
    * The ID of the object.
    */
   id: string;
+  time: any;
 }
 
 export interface MessageFragment_occurrences_edges {

--- a/src/api/generatedTypes/MessageFragment.ts
+++ b/src/api/generatedTypes/MessageFragment.ts
@@ -23,6 +23,27 @@ export interface MessageFragment_translations {
   bodyText: string;
 }
 
+export interface MessageFragment_occurrences_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+}
+
+export interface MessageFragment_occurrences_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: MessageFragment_occurrences_edges_node | null;
+}
+
+export interface MessageFragment_occurrences {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (MessageFragment_occurrences_edges | null)[];
+}
+
 export interface MessageFragment {
   /**
    * The ID of the object.
@@ -35,4 +56,5 @@ export interface MessageFragment {
   sentAt: any | null;
   event: MessageFragment_event | null;
   translations: MessageFragment_translations[];
+  occurrences: MessageFragment_occurrences;
 }

--- a/src/api/generatedTypes/Messages.ts
+++ b/src/api/generatedTypes/Messages.ts
@@ -28,6 +28,7 @@ export interface Messages_messages_edges_node_occurrences_edges_node {
    * The ID of the object.
    */
   id: string;
+  time: any;
 }
 
 export interface Messages_messages_edges_node_occurrences_edges {

--- a/src/api/generatedTypes/Messages.ts
+++ b/src/api/generatedTypes/Messages.ts
@@ -23,6 +23,27 @@ export interface Messages_messages_edges_node_translations {
   bodyText: string;
 }
 
+export interface Messages_messages_edges_node_occurrences_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+}
+
+export interface Messages_messages_edges_node_occurrences_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: Messages_messages_edges_node_occurrences_edges_node | null;
+}
+
+export interface Messages_messages_edges_node_occurrences {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (Messages_messages_edges_node_occurrences_edges | null)[];
+}
+
 export interface Messages_messages_edges_node {
   /**
    * The ID of the object.
@@ -35,6 +56,7 @@ export interface Messages_messages_edges_node {
   sentAt: any | null;
   event: Messages_messages_edges_node_event | null;
   translations: Messages_messages_edges_node_translations[];
+  occurrences: Messages_messages_edges_node_occurrences;
 }
 
 export interface Messages_messages_edges {

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -213,6 +213,10 @@
         "label": "Published",
         "sent": "Sent",
         "notSent": "Not sent"
+      },
+      "occurrences": {
+        "label": "Occurrences",
+        "all": "All Occurrences"
       }
     },
     "create": {

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -359,5 +359,8 @@
     "message": {
       "delete_title": "Delete"
     }
+  },
+  "generic": {
+    "all": "All"
   }
 }

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -213,6 +213,10 @@
         "label": "Julkaisu",
         "sent": "Lähetetty",
         "notSent": "Ei lähetetty"
+      },
+      "occurrences": {
+        "label": "Esiintymät",
+        "all": "Kaikki Esiintymät"
       }
     },
     "create": {

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -359,5 +359,8 @@
     "message": {
       "delete_title": "Poista"
     }
+  },
+  "generic": {
+    "all": "Kaikki"
   }
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -7,3 +7,15 @@ export function toDateTimeString(date: Date, locale?: string) {
     minute: '2-digit',
   });
 }
+
+export function toShortDateTimeString(date: Date, locale?: string) {
+  const dateTimeString = toDateTimeString(date, locale);
+
+  if (dateTimeString && locale === 'fi') {
+    // This is a pretty ugly way to go about it, but I couldn't find a
+    // way to use the API to remove this prefix.
+    return dateTimeString.replace(' klo', ',');
+  }
+
+  return dateTimeString;
+}

--- a/src/domain/events/eventSelect/EventSelect.tsx
+++ b/src/domain/events/eventSelect/EventSelect.tsx
@@ -3,59 +3,26 @@ import {
   ChoicesInputProps,
   TextFieldProps,
   SelectInput,
-  useQuery,
+  ReferenceInput,
 } from 'react-admin';
-
-import { Events_events_edges_node as Event } from '../../../api/generatedTypes/Events';
-
-type Choice = {
-  id: string;
-  name: string;
-};
-
-function getOptions(events: Event[]): Choice[] {
-  return events.map(({ id, name }) => ({
-    id,
-    name: name || '',
-  }));
-}
 
 // react-admin does not export the type for props for SelectInput. In
 // version 3.9.4 it used the following type.
 type SelectInputProps = ChoicesInputProps<TextFieldProps> &
   Omit<TextFieldProps, 'label' | 'helperText'>;
 
-type Props = Omit<SelectInputProps, 'choices'> & {
-  language?: string;
-  allowAll?: boolean;
-  allLabel?: string;
+// The type is missing from the bundle although the original source
+// exports it.
+type ReferenceInputProps = Parameters<typeof ReferenceInput>[0];
+type Props = Omit<ReferenceInputProps, 'children' | 'reference'> & {
+  source: string;
 };
 
-const EventSelect = ({
-  allowAll,
-  allLabel,
-  initialValue: externalInitialValue,
-  ...rest
-}: Props) => {
-  // Due to a reason I could not understand, the useGetList query always
-  // returned an empty result.
-  const { data, loading, error } = useQuery({
-    type: 'getList',
-    resource: 'events',
-    payload: {
-      pagination: {
-        page: 1,
-        perPage: 1000,
-      },
-    },
-  });
-
-  const isReady = data && !loading && !error;
-  const choices = isReady ? getOptions(data) : undefined;
-  const initialValue = isReady ? externalInitialValue : undefined;
-
+const EventSelect = (props: Props) => {
   return (
-    <SelectInput {...rest} initialValue={initialValue} choices={choices} />
+    <ReferenceInput {...props} resource="events" reference="events">
+      <SelectInput optionText="name" />
+    </ReferenceInput>
   );
 };
 

--- a/src/domain/messages/detail/MessagesDetail.tsx
+++ b/src/domain/messages/detail/MessagesDetail.tsx
@@ -8,12 +8,14 @@ import {
   EditButton,
   TopToolbar,
   useLocale,
+  FunctionField,
 } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 import Typography from '@material-ui/core/Typography';
+import Chip from '@material-ui/core/Chip';
 
 import { Message_message as Message } from '../../../api/generatedTypes/Message';
-import { toDateTimeString } from '../../../common/utils';
+import { toDateTimeString, toShortDateTimeString } from '../../../common/utils';
 import KukkuuDetailPage from '../../../common/components/kukkuuDetailPage/KukkuuDetailPage';
 import useLanguageTabs from '../hooks/useLanguageTabs';
 import { recipientSelectionChoices } from '../choices';
@@ -83,29 +85,40 @@ const MessageDetailToolbar = ({
   );
 };
 
-const useStyles = makeStyles({
-  inline: {
-    display: 'inline-flex',
-    width: '50%',
-    '& &': {
-      width: '100%',
+const useStyles = makeStyles((theme) => ({
+  showLayout: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gridTemplateRows: 'auto',
+    columnGap: theme.spacing(2) + 'px',
+    rowGap: theme.spacing(2) + 'px',
+    '& > *': {
+      gridColumn: '1 / -1',
     },
   },
-  showLayout: {
-    '& > .ra-field': {
-      marginBottom: '1rem',
-    },
+  recipientSelection: {
+    gridColumn: '1 !important',
+  },
+  event: {
+    gridColumn: '2 !important',
   },
   textField: {
     maxWidth: '600px',
     whiteSpace: 'break-spaces',
   },
-});
+  chip: {
+    marginBottom: theme.spacing(0.5) + 'px',
+    '&:not(:last-child)': {
+      marginRight: theme.spacing(0.5) + 'px',
+    },
+  },
+}));
 
 const MessagesDetail = (props: ResourceComponentPropsWithId) => {
   const classes = useStyles();
   const [languageTabsComponent, translatableField] = useLanguageTabs();
   const t = useTranslate();
+  const locale = useLocale();
 
   return (
     <KukkuuDetailPage
@@ -119,13 +132,32 @@ const MessagesDetail = (props: ResourceComponentPropsWithId) => {
           source="recipientSelection"
           label="messages.fields.recipientSelection.label"
           choices={recipientSelectionChoices}
-          className={classes.inline}
+          className={classes.recipientSelection}
         />
         <TextField
           source="event.name"
           label="messages.fields.event.label"
-          className={classes.inline}
+          className={classes.event}
           emptyText={t('messages.fields.event.all')}
+        />
+        <FunctionField
+          source="occurrences"
+          label="messages.fields.occurrences.label"
+          render={(record?: any) => {
+            const stringifiedRecords =
+              record &&
+              record.occurrences.edges.map((connection: any) =>
+                toShortDateTimeString(new Date(connection.node.time), locale)
+              );
+
+            if (stringifiedRecords.length === 0) {
+              return t('messages.fields.occurrences.all');
+            }
+
+            return stringifiedRecords.map((record: string) => (
+              <Chip key={record} label={record} className={classes.chip} />
+            ));
+          }}
         />
         <TextField
           source={translatableField('subject')}

--- a/src/domain/messages/form/MessageForm.tsx
+++ b/src/domain/messages/form/MessageForm.tsx
@@ -4,9 +4,12 @@ import {
   SimpleForm,
   SelectInput,
   SimpleFormProps,
+  FormDataConsumer,
 } from 'react-admin';
+import { makeStyles } from '@material-ui/core';
 
 import EventSelect from '../../events/eventSelect/EventSelect';
+import OccurrenceArraySelect from '../../occurrences/OccurrenceArraySelect';
 import useLanguageTabs from '../hooks/useLanguageTabs';
 import {
   validateRecipientSelection,
@@ -15,16 +18,48 @@ import {
   validateMessageForm,
 } from '../validations';
 import { recipientSelectionChoices } from '../choices';
-import styles from './messageForm.module.css';
+
+const useStyles = makeStyles((theme) => ({
+  form: {
+    '& > .MuiCardContent-root': {
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+      gridTemplateRows: 'auto',
+      columnGap: theme.spacing(2) + 'px',
+      '& > *': {
+        gridColumn: '1 / -1',
+      },
+    },
+  },
+  recipientSelection: {
+    gridColumn: '1 !important',
+  },
+  event: {
+    gridColumn: '1 !important',
+  },
+  occurrences: {
+    gridColumn: '2 !important',
+  },
+  fullWidth: {
+    width: '100%',
+  },
+}));
+
+function getInitialOccurrenceIds(record: any) {
+  if (!record?.occurrences?.edges || record.occurrences.edges.length === 0) {
+    return ['all'];
+  }
+
+  return record.occurrences.edges.map(
+    (occurrenceNode: any) => occurrenceNode.node.id
+  );
+}
 
 type Props = Omit<SimpleFormProps, 'children'>;
 
 const MessageForm = (props: Props) => {
-  const [
-    languageTabsComponent,
-    translatableField,
-    language,
-  ] = useLanguageTabs();
+  const [languageTabsComponent, translatableField] = useLanguageTabs();
+  const classes = useStyles();
 
   return (
     <SimpleForm
@@ -32,6 +67,7 @@ const MessageForm = (props: Props) => {
       redirect="show"
       validate={validateMessageForm}
       {...props}
+      className={classes.form}
     >
       {languageTabsComponent}
       <SelectInput
@@ -41,23 +77,38 @@ const MessageForm = (props: Props) => {
         validate={validateRecipientSelection}
         defaultValue="ALL"
         fullWidth
-        formClassName={styles.inline}
+        formClassName={classes.recipientSelection}
       />
       <EventSelect
         source="eventId"
         label="messages.fields.event.label"
         fullWidth
-        language={language}
         allowEmpty
         emptyValue="all"
         emptyText="messages.fields.event.all"
-        defaultValue="all"
-        formClassName={styles.inline}
+        formClassName={classes.event}
         InputLabelProps={{
           shrink: true,
         }}
         initialValue={props?.record?.event?.id || 'all'}
       />
+      <FormDataConsumer formClassName={classes.occurrences}>
+        {({ formData: { eventId }, ...rest }) =>
+          eventId &&
+          eventId !== 'all' && (
+            <OccurrenceArraySelect
+              {...rest}
+              source="occurrenceIds"
+              label="messages.fields.occurrences.label"
+              eventId={eventId}
+              fullWidth
+              className={classes.fullWidth}
+              initialValue={getInitialOccurrenceIds(props.record)}
+              allText="messages.fields.occurrences.all"
+            />
+          )
+        }
+      </FormDataConsumer>
       <TextInput
         source={translatableField('subject')}
         label="messages.fields.subject.label2"

--- a/src/domain/messages/form/messageForm.module.css
+++ b/src/domain/messages/form/messageForm.module.css
@@ -1,5 +1,0 @@
-.inline {
-  display: inline-flex;
-  margin-right: 1rem;
-  width: calc(50% - 1rem);
-}

--- a/src/domain/messages/list/MessagesList.tsx
+++ b/src/domain/messages/list/MessagesList.tsx
@@ -5,7 +5,9 @@ import {
   TextField,
   SelectField,
   useLocale,
+  FunctionField,
 } from 'react-admin';
+import { get } from 'lodash';
 
 import { toDateTimeString } from '../../../common/utils';
 import KukkuuListPage from '../../../common/components/kukkuuListPage/KukkuuListPage';
@@ -36,6 +38,19 @@ const MessagesList = (props: ResourceComponentPropsWithId) => {
         label={t('messages.fields.event.label')}
         source="event.name"
         emptyText={t('messages.fields.event.all')}
+      />
+      <FunctionField
+        label={t('messages.fields.occurrences.label')}
+        source="occurrences"
+        render={(record: any) => {
+          const occurrences = get(record, 'occurrences.edges', []);
+
+          if (occurrences.length === 0) {
+            return t('generic.all');
+          }
+
+          return occurrences.length;
+        }}
       />
       <TextField
         label={t('messages.fields.recipientCount.label')}

--- a/src/domain/messages/list/MessagesList.tsx
+++ b/src/domain/messages/list/MessagesList.tsx
@@ -37,7 +37,7 @@ const MessagesList = (props: ResourceComponentPropsWithId) => {
       <TextField
         label={t('messages.fields.event.label')}
         source="event.name"
-        emptyText={t('messages.fields.event.all')}
+        emptyText={t('generic.all')}
       />
       <FunctionField
         label={t('messages.fields.occurrences.label')}

--- a/src/domain/messages/queries/MessageQueries.ts
+++ b/src/domain/messages/queries/MessageQueries.ts
@@ -21,6 +21,7 @@ const MessageFragment = gql`
       edges {
         node {
           id
+          time
         }
       }
     }

--- a/src/domain/messages/queries/MessageQueries.ts
+++ b/src/domain/messages/queries/MessageQueries.ts
@@ -17,6 +17,13 @@ const MessageFragment = gql`
       subject
       bodyText
     }
+    occurrences {
+      edges {
+        node {
+          id
+        }
+      }
+    }
   }
 `;
 

--- a/src/domain/occurrences/OccurrenceArraySelect.tsx
+++ b/src/domain/occurrences/OccurrenceArraySelect.tsx
@@ -1,0 +1,102 @@
+import React, { ChangeEvent } from 'react';
+import {
+  SelectArrayInput,
+  ReferenceArrayInput,
+  useLocale,
+  useTranslate,
+} from 'react-admin';
+import { useField, useForm } from 'react-final-form';
+
+import { Occurrence_occurrence as Occurrence } from '../../api/generatedTypes/Occurrence';
+import { toShortDateTimeString } from '../../common/utils';
+
+const AllChoice = ({
+  children,
+  choices,
+  allChoiceLabel,
+  getChoices,
+  ...rest
+}: any) => {
+  return React.cloneElement(children, {
+    ...rest,
+    choices: [{ id: 'all', name: allChoiceLabel }, ...getChoices(choices)],
+  });
+};
+
+function getFilters(eventId?: string): Record<string, string> | undefined {
+  if (!eventId) {
+    return;
+  }
+
+  return {
+    eventId,
+  };
+}
+
+type ReferenceArrayInputProps = Parameters<typeof ReferenceArrayInput>[0];
+type Props = Omit<ReferenceArrayInputProps, 'children' | 'reference'> & {
+  source: string;
+  eventId?: string;
+  allText: string;
+};
+
+const OccurrenceArraySelect = ({ eventId, allText, ...rest }: Props) => {
+  const locale = useLocale();
+  const filter = getFilters(eventId);
+  const field = useField(rest.source);
+  const form = useForm();
+  const t = useTranslate();
+
+  // By default the multi select component does not explicitly have an
+  // "all" option. This custom handler implements behavior for the all
+  // option.
+  // - when the user deselects all choices, all is selected
+  // - when the user selects some (other) option (than all), "all"
+  //   selection is removed
+  // - when the user selects "all", all other choices are removed
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const previousValues = field.input.value;
+    // The value is actually an array because we are using a
+    // multi select
+    const nextValues = (e.target.value as unknown) as string[];
+    const wasAllSelected = previousValues.includes('all');
+    const willHaveOtherValueThanAll = nextValues.length > 0;
+    const willHaveNoValue = nextValues.length === 0;
+    const allWillBeAdded =
+      !previousValues.includes('all') && nextValues.includes('all');
+
+    if (wasAllSelected && willHaveOtherValueThanAll) {
+      form.change(
+        field.input.name,
+        nextValues.filter((value: string) => value !== 'all')
+      );
+    } else if (willHaveNoValue || allWillBeAdded) {
+      form.change(field.input.name, ['all']);
+    } else {
+      form.change(field.input.name, nextValues);
+    }
+  };
+
+  const getChoices = (records: Occurrence[]) => {
+    return records.map(({ id, time }) => ({
+      id,
+      name: toShortDateTimeString(new Date(time), locale),
+    }));
+  };
+
+  return (
+    <ReferenceArrayInput
+      {...rest}
+      resource="occurrences"
+      reference="occurrences"
+      filter={filter}
+      onChange={handleChange}
+    >
+      <AllChoice allChoiceLabel={t(allText)} getChoices={getChoices}>
+        <SelectArrayInput />
+      </AllChoice>
+    </ReferenceArrayInput>
+  );
+};
+
+export default OccurrenceArraySelect;

--- a/src/domain/occurrences/api/OccurrenceApi.ts
+++ b/src/domain/occurrences/api/OccurrenceApi.ts
@@ -28,7 +28,10 @@ moment.tz.setDefault('Europe/Helsinki');
 const getOccurrences: MethodHandler = async (params: MethodHandlerParams) => {
   const response: ApolloQueryResult<ApiOccurrences> = await queryHandler({
     query: occurrencesQuery,
-    variables: { projectId: getProjectId(), eventId: params.id },
+    variables: {
+      projectId: getProjectId(),
+      ...params.filter,
+    },
   });
   return handleApiConnection(response.data.occurrences);
 };
@@ -108,6 +111,14 @@ const setEnrolmentAttendance = async (
   return { data: response.data };
 };
 
+const getOccurrencesManyReference = async (params: MethodHandlerParams) => {
+  const response: ApolloQueryResult<ApiOccurrences> = await queryHandler({
+    query: occurrencesQuery,
+    variables: { projectId: getProjectId(), eventId: params.id },
+  });
+  return handleApiConnection(response.data.occurrences);
+};
+
 export {
   getOccurrences,
   getOccurrence,
@@ -115,4 +126,5 @@ export {
   updateOccurrence,
   deleteOccurrence,
   setEnrolmentAttendance,
+  getOccurrencesManyReference,
 };


### PR DESCRIPTION
## Description

Adds ability for users to create messages with occurrences, to edit occurrences in messages, to see selected occurrences in detail view and to select number of occurrences in list view.

I had to implement a bit of custom logic into the `ArraySelectInput` for an occurrence, because I wasn't able to find a way to add an "all" value through the default API.

As an unrelated change in this PR, I cleaned up the implementation of `EventSelect` in order to change it to be more in line with the API of react-admin.

## Context

Filtering based on occurrence allows user to target visitors spanning a specific time for instance.

[KK-610](https://helsinkisolutionoffice.atlassian.net/browse/KK-610)

## How Has This Been Tested?

I modified the browsers tests to check that the occurrence count is shown in the list view.

## Manual Testing Instructions for Reviewers

As a logged in admin user in message list view

1. Click on create a new mesage ("Uusi")
1. Select event with occurrences
1. Select n occurrences
    * Optional: Select an occurrence -> expect "all" to be deselected
    * Optional: Select an occurrence, then select all -> expect only all to be selected
    * Optional: Select an occurrence, then deselect the occurrence -> expect "all" to be selected
1. Sill subject and body
1. Save
1. Expect occurrence count of n to be shown in list view
1. Click on the created message
1. Expect detail view to show occurrences as chips
1. Click on edit
1. Expect occurrences to be pre-selected correctly
1. Optional: Go back to edit view and send the message -> Expect message to send without errors
    * If possible, ensure that the message doesn't have many recipients

If you wish, you can delete the message you created.