### PR TITLE
Ignore missing reference error

### DIFF
--- a/src/domain/events/eventSelect/EventSelect.tsx
+++ b/src/domain/events/eventSelect/EventSelect.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
-import {
-  ChoicesInputProps,
-  TextFieldProps,
-  SelectInput,
-  ReferenceInput,
-} from 'react-admin';
-
-// react-admin does not export the type for props for SelectInput. In
-// version 3.9.4 it used the following type.
-type SelectInputProps = ChoicesInputProps<TextFieldProps> &
-  Omit<TextFieldProps, 'label' | 'helperText'>;
+import { SelectInput, ReferenceInput } from 'react-admin';
+import omit from 'lodash/omit';
 
 // The type is missing from the bundle although the original source
 // exports it.
@@ -18,10 +9,33 @@ type Props = Omit<ReferenceInputProps, 'children' | 'reference'> & {
   source: string;
 };
 
+function ignoreNoReferenceErrorWhenEmptyValue(props: any) {
+  const {
+    meta,
+    input: { value },
+    emptyValue,
+  } = props;
+
+  if (value === emptyValue) {
+    return { ...props, meta: omit(meta, 'error') };
+  }
+
+  return props;
+}
+
+const HideNoReferenceError = ({ children, ...props }: any) => {
+  return React.cloneElement(
+    children,
+    ignoreNoReferenceErrorWhenEmptyValue(props)
+  );
+};
+
 const EventSelect = (props: Props) => {
   return (
     <ReferenceInput {...props} resource="events" reference="events">
-      <SelectInput optionText="name" />
+      <HideNoReferenceError>
+        <SelectInput optionText="name" />
+      </HideNoReferenceError>
     </ReferenceInput>
   );
 };


### PR DESCRIPTION
## Description

This error does not stop the form from submitting.

It seems that react-admin will always yield a missing reference error
when the selected value does not equal an id of one of the records. I'm
not sure whether this is a bug or whether we are using the component in
an unsupported way. For now I have implemented a cheap fix that hides
errors for the empty value.

## Context

Without this change users will see an error when they select the all events option.

## How Has This Been Tested?

I have tested this manually.

## Manual Testing Instructions for Reviewers

As a logged in admin level user in the create messages view

1. Choose an event
1. Choose all events
1. Click on title
1. Expect to see no error in the event select field