### PR TITLE
KK-635 | Show recipient count in message details view

### DIFF
--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -171,7 +171,7 @@
       "error": "Message send failed",
       "confirm": {
         "title": "Send message \"%{messageSubject}\"",
-        "content": "Are you sure that you want to send this message?"
+        "content": "%{recipientCount} recipients. Are you sure that you want to send this message?"
       }
     },
     "fields": {

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -207,7 +207,8 @@
         "all": "All Events"
       },
       "recipientCount": {
-        "label": "Recipient count"
+        "label": "Recipient count",
+        "label2": "Recipients"
       },
       "sentAt": {
         "label": "Published",

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -171,7 +171,7 @@
       "error": "Viestin lähetys epäonnistui",
       "confirm": {
         "title": "Lähetä viesti \"%{messageSubject}\"",
-        "content": "Oletko varma, että haluat lähettää tämän viestin?"
+        "content": "%{recipientCount} vastaanottajaa. Oletko varma, että haluat lähettää tämän viestin?"
       }
     },
     "fields": {

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -207,7 +207,8 @@
         "all": "Kaikki tapahtumat"
       },
       "recipientCount": {
-        "label": "Vastaanottajia"
+        "label": "Vastaanottajia",
+        "label2": "Vastaanottajaa"
       },
       "sentAt": {
         "label": "Julkaisu",

--- a/src/domain/messages/detail/MessageSendButton.tsx
+++ b/src/domain/messages/detail/MessageSendButton.tsx
@@ -74,6 +74,9 @@ const MessagesSendButton = ({ basePath, record, className }: Props) => {
         content="messages.send.confirm.content"
         onConfirm={handleSend}
         onClose={handleDialogClose}
+        translateOptions={{
+          recipientCount: record?.recipientCount || '?',
+        }}
       />
     </>
   );

--- a/src/domain/messages/detail/MessagesDetail.tsx
+++ b/src/domain/messages/detail/MessagesDetail.tsx
@@ -85,6 +85,37 @@ const MessageDetailToolbar = ({
   );
 };
 
+const useRecipientCountFieldStyles = makeStyles((theme) => ({
+  container: {
+    fontSize: theme.typography.fontSize,
+    fontFamily: theme.typography.fontFamily,
+  },
+  value: {
+    fontWeight: theme.typography.fontWeightBold,
+  },
+}));
+
+const RecipientCountField = ({ record }: any) => {
+  const t = useTranslate();
+  const classes = useRecipientCountFieldStyles();
+
+  const sentAt = record?.sentAt;
+  const recipientCount = record?.recipientCount || '?';
+
+  // If message is sent, the recipient count is shown under the message
+  // title and we don't need to show it in the message body.
+  if (sentAt) {
+    return null;
+  }
+
+  return (
+    <div className={classes.container}>
+      <span className={classes.value}>{recipientCount}</span>{' '}
+      {t('messages.fields.recipientCount.label2')}
+    </div>
+  );
+};
+
 const useStyles = makeStyles((theme) => ({
   showLayout: {
     display: 'grid',
@@ -128,6 +159,7 @@ const MessagesDetail = (props: ResourceComponentPropsWithId) => {
     >
       <SimpleShowLayout className={classes.showLayout}>
         {languageTabsComponent}
+        <RecipientCountField />
         <SelectField
           source="recipientSelection"
           label="messages.fields.recipientSelection.label"

--- a/src/domain/messages/detail/MessagesDetail.tsx
+++ b/src/domain/messages/detail/MessagesDetail.tsx
@@ -18,6 +18,7 @@ import { Message_message as Message } from '../../../api/generatedTypes/Message'
 import { toDateTimeString, toShortDateTimeString } from '../../../common/utils';
 import KukkuuDetailPage from '../../../common/components/kukkuuDetailPage/KukkuuDetailPage';
 import useLanguageTabs from '../hooks/useLanguageTabs';
+import MessageRecipientCountField from '../fields/MessageRecipientCountField';
 import { recipientSelectionChoices } from '../choices';
 import MessageSendButton from './MessageSendButton';
 
@@ -85,37 +86,6 @@ const MessageDetailToolbar = ({
   );
 };
 
-const useRecipientCountFieldStyles = makeStyles((theme) => ({
-  container: {
-    fontSize: theme.typography.fontSize,
-    fontFamily: theme.typography.fontFamily,
-  },
-  value: {
-    fontWeight: theme.typography.fontWeightBold,
-  },
-}));
-
-const RecipientCountField = ({ record }: any) => {
-  const t = useTranslate();
-  const classes = useRecipientCountFieldStyles();
-
-  const sentAt = record?.sentAt;
-  const recipientCount = record?.recipientCount || '?';
-
-  // If message is sent, the recipient count is shown under the message
-  // title and we don't need to show it in the message body.
-  if (sentAt) {
-    return null;
-  }
-
-  return (
-    <div className={classes.container}>
-      <span className={classes.value}>{recipientCount}</span>{' '}
-      {t('messages.fields.recipientCount.label2')}
-    </div>
-  );
-};
-
 const useStyles = makeStyles((theme) => ({
   showLayout: {
     display: 'grid',
@@ -159,7 +129,7 @@ const MessagesDetail = (props: ResourceComponentPropsWithId) => {
     >
       <SimpleShowLayout className={classes.showLayout}>
         {languageTabsComponent}
-        <RecipientCountField />
+        <MessageRecipientCountField />
         <SelectField
           source="recipientSelection"
           label="messages.fields.recipientSelection.label"

--- a/src/domain/messages/fields/MessageRecipientCountField.tsx
+++ b/src/domain/messages/fields/MessageRecipientCountField.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useTranslate } from 'react-admin';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    fontSize: theme.typography.fontSize,
+    fontFamily: theme.typography.fontFamily,
+  },
+  value: {
+    fontWeight: theme.typography.fontWeightBold,
+  },
+}));
+
+const MessageRecipientCountField = ({ record }: any) => {
+  const t = useTranslate();
+  const classes = useStyles();
+
+  const sentAt = record?.sentAt;
+  const recipientCount = record?.recipientCount || '?';
+
+  // If message is sent, the recipient count is shown under the message
+  // title and we don't need to show it in the message body.
+  if (sentAt) {
+    return null;
+  }
+
+  return (
+    <div className={classes.container}>
+      <span className={classes.value}>{recipientCount}</span>{' '}
+      {t('messages.fields.recipientCount.label2')}
+    </div>
+  );
+};
+
+export default MessageRecipientCountField;


### PR DESCRIPTION
## Description

Adds the recipient count to message details view when the message is unsent.

Also adds the recipient count into the confirmation modal before the message is sent.

## Context

Users can use the count of recipients as guidance about whether they have configured their recipients correctly.

[KK-635](https://helsinkisolutionoffice.atlassian.net/browse/KK-635)

## How Has This Been Tested?

This has been tested manually by checking that these values are visible.

## Manual Testing Instructions for Reviewers

1. Navigate into an unsent message
1. Expect to see recipient count in the details view
1. Click on "Send"
1. Expect confirmation window to show recipient count