### PR TITLE
KK-636 | Hide recipient filter fields when not relevant

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --env=jsdom-fourteen",
     "eject": "react-scripts eject",
     "lint": "eslint --ext js,ts,tsx src",
     "ci": "CI=true yarn test --verbose --runInBand --coverage",

--- a/src/domain/messages/form/MessageForm.tsx
+++ b/src/domain/messages/form/MessageForm.tsx
@@ -148,9 +148,10 @@ const MessageForm = (props: Props) => {
         }
       </FormDataConsumer>
       <FormDataConsumer formClassName={classes.occurrences}>
-        {({ formData: { eventId }, ...rest }) =>
+        {({ formData: { eventId, recipientSelection }, ...rest }) =>
           eventId &&
-          eventId !== 'all' && (
+          eventId !== 'all' &&
+          recipientSelection !== 'INVITED' && (
             <OccurrenceArraySelect
               {...rest}
               source="occurrenceIds"

--- a/src/domain/messages/form/__tests__/MessageForm.test.jsx
+++ b/src/domain/messages/form/__tests__/MessageForm.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { TestContext } from 'react-admin';
+import {
+  render,
+  getByText,
+  queryByText,
+  fireEvent,
+  getByRole,
+  screen,
+} from '@testing-library/react';
+
+import MessageForm from '../MessageForm';
+
+const defaultProps = {
+  location: {},
+  match: {},
+};
+const getWrapper = (props) =>
+  render(
+    <TestContext>
+      <MessageForm {...defaultProps} {...props} />
+    </TestContext>
+  );
+
+const getSelectInputByLabelText = (container, labelText) => {
+  const labelSpan = getByText(container, labelText, {
+    selector: 'label > *',
+  });
+  const label = labelSpan.parentElement;
+  const labelParent = label.parentElement;
+
+  return labelParent.querySelector('input');
+};
+
+const querySelectInputByLabelText = (container, labelText) => {
+  const labelSpan = queryByText(container, labelText, {
+    selector: 'label > *',
+  });
+
+  if (!labelSpan) {
+    return null;
+  }
+
+  return labelSpan.parentElement.parentElement.querySelector('input');
+};
+
+const chooseSelectInputOption = async (container, selectInput, optionLabel) => {
+  fireEvent.mouseDown(getByRole(selectInput.parentElement, 'button'));
+
+  const option = await screen.getByRole('option', { name: optionLabel });
+
+  fireEvent.click(option);
+};
+
+describe('<MessageForm />', () => {
+  it('should not show event select unless the user has chosen some other recipient count than all', async () => {
+    const { container, queryAllByText } = getWrapper();
+
+    expect(
+      querySelectInputByLabelText(container, 'messages.fields.event.label')
+    ).toBeFalsy();
+
+    await chooseSelectInputOption(
+      container,
+      getSelectInputByLabelText(
+        container,
+        'messages.fields.recipientSelection.label'
+      ),
+      'messages.fields.recipientSelection.choices.INVITED.label'
+    );
+
+    expect(
+      queryAllByText('messages.fields.event.label').length
+    ).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Description

Some fields do not have any effect depending on the value of another field. This PR tackles these two cases:

* When receivers is set to "All", the event select and occurrence won't be shown
* When receivers is set to "Invited", the occurrence select won't be shown

Moreover, values in these selects are nullified
* If the user selects recipients as "Notified" and then an event, and then selects occurrences, and then selects "All" recipients, the selections for event and occurrences are reset.
* Whenever the user selects an event, the selection for occurrences is reset.

## Context

This change makes it easier for the user to understand what combinations are possible.

[KK-636](https://helsinkisolutionoffice.atlassian.net/browse/KK-636)

## How Has This Been Tested?

I added one simple tests, but noticed that it was difficult to mock the form as it has a few inputs that depend on the API.

## Manual Testing Instructions for Reviewers

In the message creation/editing view

1. Expect to not see event or occurrence select when recipients are set to all
1. Expect to see event select when recipient are set to "Invited", and expect to not see occurrence select when an even is selected
1. Expect for occurrence selection to reset after event selection is changed
1. Expect event and occurrence selection to reset when recipient are set to "All"