### PR TITLE
KK-644 | Add event groups to event list

### DIFF
--- a/browser-tests/eventsAndEventGrouspFeature.ts
+++ b/browser-tests/eventsAndEventGrouspFeature.ts
@@ -1,0 +1,18 @@
+import { routes } from './pages/routes';
+import { login } from './utils/login';
+import { navigation } from './pages/navigation';
+import { eventsListPage } from './pages/events';
+
+fixture`Event groups feature`
+  .page(routes.eventsList())
+  .beforeEach(async (t) => {
+    await login(t);
+    await t.click(navigation.events);
+  });
+
+test('As an admin I want to see events groups within the event list', async (t) => {
+  // Expect the list to have event groups
+  await t
+    .expect(eventsListPage.listBody.withText('TAPAHTUMARYHMÄ').count)
+    .gt(0);
+});

--- a/browser-tests/messageFeature.ts
+++ b/browser-tests/messageFeature.ts
@@ -26,9 +26,6 @@ fixture`Messages feature`
   .beforeEach(async (t) => {
     await login(t);
 
-    // Wait for authorization to finish
-    await t.wait(3000); // 3s
-
     await t.click(navigation.messages);
 
     // Add a test message to context

--- a/browser-tests/pages/events.ts
+++ b/browser-tests/pages/events.ts
@@ -1,0 +1,5 @@
+import { Selector } from 'testcafe';
+
+export const eventsListPage = {
+  listBody: Selector('.MuiTableBody-root'),
+};

--- a/browser-tests/pages/navigation.ts
+++ b/browser-tests/pages/navigation.ts
@@ -4,4 +4,7 @@ export const navigation = {
   messages: Selector(
     '.MuiButtonBase-root.MuiListItem-root.MuiMenuItem-root'
   ).withAttribute('href', '/messages'),
+  events: Selector(
+    '.MuiButtonBase-root.MuiListItem-root.MuiMenuItem-root'
+  ).withAttribute('href', '/events-and-event-groups'),
 };

--- a/browser-tests/pages/routes.ts
+++ b/browser-tests/pages/routes.ts
@@ -6,4 +6,5 @@ export const routes = {
   messagesDetails: (messageId: string) =>
     `${envUrl()}/messages/${messageId}/show`,
   messagesEdit: (messageId: string) => `${envUrl()}/messages/${messageId}`,
+  eventsList: () => `${envUrl()}/events-and-events-groups`,
 };

--- a/browser-tests/utils/login.ts
+++ b/browser-tests/utils/login.ts
@@ -8,5 +8,7 @@ export const login = async (t: TestController) => {
     .click(ssoLogin.loginLink)
     .typeText(ssoLogin.username, testUsername())
     .typeText(ssoLogin.password, testUserPassword())
-    .click(ssoLogin.loginButton);
+    .click(ssoLogin.loginButton)
+    // Wait for authorization to finish
+    .wait(3000); // 3s
 };

--- a/src/api/generatedTypes/EventFragment.ts
+++ b/src/api/generatedTypes/EventFragment.ts
@@ -1,0 +1,48 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { EventParticipantsPerInvite } from "./globalTypes";
+
+// ====================================================
+// GraphQL fragment: EventFragment
+// ====================================================
+
+export interface EventFragment_occurrences_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+}
+
+export interface EventFragment_occurrences_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: EventFragment_occurrences_edges_node | null;
+}
+
+export interface EventFragment_occurrences {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (EventFragment_occurrences_edges | null)[];
+}
+
+export interface EventFragment {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+  image: string;
+  participantsPerInvite: EventParticipantsPerInvite;
+  /**
+   * In minutes
+   */
+  duration: number | null;
+  capacityPerOccurrence: number;
+  publishedAt: any | null;
+  occurrences: EventFragment_occurrences;
+}

--- a/src/api/generatedTypes/EventsAndEventGroups.ts
+++ b/src/api/generatedTypes/EventsAndEventGroups.ts
@@ -1,0 +1,133 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { EventParticipantsPerInvite } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: EventsAndEventGroups
+// ====================================================
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode_occurrences_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode_occurrences_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode_occurrences_edges_node | null;
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode_occurrences {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode_occurrences_edges | null)[];
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+  image: string;
+  participantsPerInvite: EventParticipantsPerInvite;
+  /**
+   * In minutes
+   */
+  duration: number | null;
+  capacityPerOccurrence: number;
+  publishedAt: any | null;
+  occurrences: EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode_occurrences;
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges_node_occurrences_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges_node_occurrences_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges_node_occurrences_edges_node | null;
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges_node_occurrences {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges_node_occurrences_edges | null)[];
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+  image: string;
+  participantsPerInvite: EventParticipantsPerInvite;
+  /**
+   * In minutes
+   */
+  duration: number | null;
+  capacityPerOccurrence: number;
+  publishedAt: any | null;
+  occurrences: EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges_node_occurrences;
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges_node | null;
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges | null)[];
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+  events: EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events;
+}
+
+export type EventsAndEventGroups_eventsAndEventGroups_edges_node = EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode | EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode;
+
+export interface EventsAndEventGroups_eventsAndEventGroups_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: EventsAndEventGroups_eventsAndEventGroups_edges_node | null;
+}
+
+export interface EventsAndEventGroups_eventsAndEventGroups {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (EventsAndEventGroups_eventsAndEventGroups_edges | null)[];
+}
+
+export interface EventsAndEventGroups {
+  eventsAndEventGroups: EventsAndEventGroups_eventsAndEventGroups | null;
+}
+
+export interface EventsAndEventGroupsVariables {
+  projectId?: string | null;
+}

--- a/src/api/relayList.ts
+++ b/src/api/relayList.ts
@@ -1,0 +1,32 @@
+type Edge<Node> = {
+  node?: Node | null;
+};
+type TRelayList<Node> = {
+  edges?: (Edge<Node> | null)[] | null;
+} | null;
+
+class RelayList<Node> {
+  data?: TRelayList<Node>;
+
+  constructor(data?: TRelayList<Node>) {
+    this.data = data;
+  }
+
+  get items(): Exclude<Node, null>[] {
+    if (!this.data?.edges) {
+      return [];
+    }
+
+    return this.data?.edges
+      .map((edge) => edge?.node)
+      .filter((node): node is Exclude<Node, null> => Boolean(node));
+  }
+}
+
+function RelayListFactory<Node>(): (
+  data?: TRelayList<Node>
+) => RelayList<Node> {
+  return (data?: TRelayList<Node>) => new RelayList<Node>(data);
+}
+
+export default RelayListFactory;

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -122,6 +122,9 @@
       },
       "publishedAt": {
         "label": "Published at",
+        "published": {
+          "label": "Published"
+        },
         "values": {
           "NOT_PUBLISHED": "Not published"
         }
@@ -183,7 +186,19 @@
   },
   "eventsAndEventGroups": {
     "list": {
-      "label": "Event list"
+      "label": "Event list",
+      "type": {
+        "label": "Type",
+        "event": {
+          "label": "Event"
+        },
+        "eventGroup": {
+          "label": "Event Group"
+        }
+      },
+      "eventCount": {
+        "label": "Events"
+      }
     }
   },
   "languages": {

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -122,6 +122,9 @@
       },
       "publishedAt": {
         "label": "Julkaisu",
+        "published": {
+          "label": "Julkaistu"
+        },
         "values": {
           "NOT_PUBLISHED": "Ei julkaistu"
         }
@@ -183,7 +186,19 @@
   },
   "eventsAndEventGroups": {
     "list": {
-      "label": "Tapahtumalista"
+      "label": "Tapahtumalista",
+      "type": {
+        "label": "Tyyppi",
+        "event": {
+          "label": "Tapahtuma"
+        },
+        "eventGroup": {
+          "label": "Tapahtumaryhmä"
+        }
+      },
+      "eventCount": {
+        "label": "Tapahtumia"
+      }
     }
   },
   "languages": {

--- a/src/domain/application/layout/kukkuuListPage/KukkuuListPage.tsx
+++ b/src/domain/application/layout/kukkuuListPage/KukkuuListPage.tsx
@@ -1,9 +1,5 @@
 import React, { ReactNode } from 'react';
-import {
-  Datagrid,
-  ResourceComponentPropsWithId,
-  DatagridProps,
-} from 'react-admin';
+import { Datagrid, DatagridProps, ListProps } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 
 import KukkuuList from './KukkuuList';
@@ -21,7 +17,7 @@ const useStyles = makeStyles({
 type Props = {
   pageTitle: string;
   children: ReactNode;
-  reactAdminProps: ResourceComponentPropsWithId;
+  reactAdminProps: ListProps;
   datagridProps?: DatagridProps;
 };
 

--- a/src/domain/eventsAndEventGroups/api/eventsAndEventGroupsApi.ts
+++ b/src/domain/eventsAndEventGroups/api/eventsAndEventGroupsApi.ts
@@ -1,9 +1,15 @@
 import { MethodHandlerParams } from '../../../api/types';
-import { getEvents } from '../../events/api/EventApi';
+import { queryHandler, handleApiConnection } from '../../../api/utils/apiUtils';
+import { getProjectId } from '../../profile/utils';
+import { eventsAndEventGroupsQuery } from '../queries/EventsAndEventGroupsQueries';
 
 async function getEventsAndEventGroups(params: MethodHandlerParams) {
-  // Return events until we can use the events and event groups API
-  return getEvents(params);
+  const response = await queryHandler({
+    query: eventsAndEventGroupsQuery,
+    variables: { projectId: getProjectId() },
+  });
+
+  return handleApiConnection(response.data.eventsAndEventGroups);
 }
 
 const eventsAsEventGroupsApi = {

--- a/src/domain/eventsAndEventGroups/queries/EventsAndEventGroupsQueries.ts
+++ b/src/domain/eventsAndEventGroups/queries/EventsAndEventGroupsQueries.ts
@@ -1,0 +1,48 @@
+import { gql } from '@apollo/client';
+
+const EventFragment = gql`
+  fragment EventFragment on EventNode {
+    id
+    name
+    image
+    participantsPerInvite
+    duration
+    capacityPerOccurrence
+    publishedAt
+    duration
+    occurrences {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+export const eventsAndEventGroupsQuery = gql`
+  query EventsAndEventGroups($projectId: ID) {
+    eventsAndEventGroups(projectId: $projectId) {
+      edges {
+        node {
+          ... on EventNode {
+            ...EventFragment
+          }
+          ... on EventGroupNode {
+            id
+            name
+            events {
+              edges {
+                node {
+                  ...EventFragment
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  ${EventFragment}
+`;


### PR DESCRIPTION
## Description

integrates the UI to the new API, which allows events and events groups to be shown on the same list.

## Context

[KK-644](https://helsinkisolutionoffice.atlassian.net/browse/KK-644)

## How Has This Been Tested?

I've added a browser test that checks that it can find at least one event group within the events and events groups list.

## Manual Testing Instructions for Reviewers

As a logged in user

1. Navigate to the events view
1. Expect to see events and event groups
1. Expect data columns to behave expectedly
1. Expect clicking event group to take you to the event group view and clicking on an event to take you to the event view
1. Expect correct columns to be highlighted with bold