### PR TITLE
KK-634 | Add event group details view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- View for viewing event group details
+
 ### Changed
 
 - apollo-client version to 3.0 branch

--- a/browser-tests/eventsAndEventGrouspFeature.ts
+++ b/browser-tests/eventsAndEventGrouspFeature.ts
@@ -2,6 +2,11 @@ import { routes } from './pages/routes';
 import { login } from './utils/login';
 import { navigation } from './pages/navigation';
 import { eventsListPage } from './pages/events';
+import { eventGroupsDetailPage } from './pages/eventGroups';
+
+function includes(text: string, values: string[]): boolean {
+  return true;
+}
 
 fixture`Event groups feature`
   .page(routes.eventsList())
@@ -10,9 +15,36 @@ fixture`Event groups feature`
     await t.click(navigation.events);
   });
 
-test('As an admin I want to see events groups within the event list', async (t) => {
+test('As an admin I want to see event groups within the event list', async (t) => {
   // Expect the list to have event groups
   await t
     .expect(eventsListPage.listBody.withText('TAPAHTUMARYHMÄ').count)
     .gt(0);
+});
+
+test('As an admin I want to be able to open an event group and see the events in the event group', async (t) => {
+  const eventGroupRow = eventsListPage.anyEventGroup.child();
+  const eventGroupName = await eventGroupRow.child().nth(0).textContent;
+
+  // Go to event group
+  await t.click(eventGroupRow);
+
+  // Assert that we are in the correct page
+  await t.expect(eventGroupsDetailPage.title.textContent).eql(eventGroupName);
+
+  // Assert that there's a list of events
+  const listHeaders = await eventGroupsDetailPage.eventListHeader.textContent;
+  await t
+    .expect(
+      includes(listHeaders, [
+        'Nimi',
+        'Osallistujat kutsua kohden',
+        'Kesto',
+        'Kokonaiskapasiteetti',
+        'Esiintymiä',
+        'Ilmoittautuneita',
+      ])
+    )
+    .ok();
+  await t.expect(eventGroupsDetailPage.eventList.childNodeCount).gt(0);
 });

--- a/browser-tests/pages/eventGroups.ts
+++ b/browser-tests/pages/eventGroups.ts
@@ -1,0 +1,7 @@
+import { Selector } from 'testcafe';
+
+export const eventGroupsDetailPage = {
+  title: Selector('h1'),
+  eventListHeader: Selector('.MuiTableHead-root > .MuiTableRow-root'),
+  eventList: Selector('.MuiTableBody-root'),
+};

--- a/browser-tests/pages/events.ts
+++ b/browser-tests/pages/events.ts
@@ -2,4 +2,5 @@ import { Selector } from 'testcafe';
 
 export const eventsListPage = {
   listBody: Selector('.MuiTableBody-root'),
+  anyEventGroup: Selector('.MuiTableBody-root').withText('TAPAHTUMARYHMÄ'),
 };

--- a/src/api/generatedTypes/EventGroup.ts
+++ b/src/api/generatedTypes/EventGroup.ts
@@ -1,0 +1,83 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { EventParticipantsPerInvite } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: EventGroup
+// ====================================================
+
+export interface EventGroup_eventGroup_events_edges_node_occurrences_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  enrolmentCount: number;
+}
+
+export interface EventGroup_eventGroup_events_edges_node_occurrences_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: EventGroup_eventGroup_events_edges_node_occurrences_edges_node | null;
+}
+
+export interface EventGroup_eventGroup_events_edges_node_occurrences {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (EventGroup_eventGroup_events_edges_node_occurrences_edges | null)[];
+}
+
+export interface EventGroup_eventGroup_events_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+  image: string;
+  participantsPerInvite: EventParticipantsPerInvite;
+  /**
+   * In minutes
+   */
+  duration: number | null;
+  capacityPerOccurrence: number;
+  publishedAt: any | null;
+  occurrences: EventGroup_eventGroup_events_edges_node_occurrences;
+}
+
+export interface EventGroup_eventGroup_events_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: EventGroup_eventGroup_events_edges_node | null;
+}
+
+export interface EventGroup_eventGroup_events {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (EventGroup_eventGroup_events_edges | null)[];
+}
+
+export interface EventGroup_eventGroup {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+  events: EventGroup_eventGroup_events;
+}
+
+export interface EventGroup {
+  /**
+   * The ID of the object
+   */
+  eventGroup: EventGroup_eventGroup | null;
+}
+
+export interface EventGroupVariables {
+  id: string;
+}

--- a/src/api/generatedTypes/EventGroupEventFragment.ts
+++ b/src/api/generatedTypes/EventGroupEventFragment.ts
@@ -1,0 +1,49 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { EventParticipantsPerInvite } from "./globalTypes";
+
+// ====================================================
+// GraphQL fragment: EventGroupEventFragment
+// ====================================================
+
+export interface EventGroupEventFragment_occurrences_edges_node {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  enrolmentCount: number;
+}
+
+export interface EventGroupEventFragment_occurrences_edges {
+  /**
+   * The item at the end of the edge
+   */
+  node: EventGroupEventFragment_occurrences_edges_node | null;
+}
+
+export interface EventGroupEventFragment_occurrences {
+  /**
+   * Contains the nodes in this connection.
+   */
+  edges: (EventGroupEventFragment_occurrences_edges | null)[];
+}
+
+export interface EventGroupEventFragment {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+  image: string;
+  participantsPerInvite: EventParticipantsPerInvite;
+  /**
+   * In minutes
+   */
+  duration: number | null;
+  capacityPerOccurrence: number;
+  publishedAt: any | null;
+  occurrences: EventGroupEventFragment_occurrences;
+}

--- a/src/common/__tests__/utils.test.js
+++ b/src/common/__tests__/utils.test.js
@@ -1,0 +1,9 @@
+import { sum } from '../utils';
+
+describe('common utils', () => {
+  describe('sum', () => {
+    it('should add numbers together', () => {
+      expect(sum([1, 4, 10])).toEqual(15);
+    });
+  });
+});

--- a/src/common/components/localDataGrid/LocalDataGrid.tsx
+++ b/src/common/components/localDataGrid/LocalDataGrid.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Children, ReactElement } from 'react';
 import { Table, TableHead, TableRow, TableBody } from '@material-ui/core';
 import {
   useDatagridStyles,
@@ -6,6 +6,17 @@ import {
   DatagridCell,
 } from 'react-admin';
 import get from 'lodash/get';
+
+function disableSorting(field: ReactElement) {
+  return {
+    ...field,
+    props: {
+      ...field.props,
+
+      sortable: false,
+    },
+  };
+}
 
 const LocalDataGrid = ({
   children,
@@ -24,7 +35,7 @@ const LocalDataGrid = ({
           {Children.map(children, (field, index) => (
             <DatagridHeaderCell
               className={classes.headerCell}
-              field={field}
+              field={disableSorting(field)}
               isSorting={false}
               key={(field.props as any).source || index}
               resource={resource}

--- a/src/common/components/localDataGrid/LocalDataGrid.tsx
+++ b/src/common/components/localDataGrid/LocalDataGrid.tsx
@@ -24,9 +24,16 @@ const LocalDataGrid = ({
   record,
   source,
   basePath,
+  rowClick,
 }: any) => {
   const classes = useDatagridStyles();
+
+  const handleRowClick = (localRecord?: any) => {
+    rowClick(localRecord);
+  };
+
   const localRecords = get(record, source, []);
+  const isHover = Boolean(handleRowClick);
 
   return (
     <Table className={classes.table} size="small">
@@ -52,7 +59,11 @@ const LocalDataGrid = ({
       </TableHead>
       <TableBody>
         {localRecords.map((localRecord: any) => (
-          <TableRow key={localRecord.id}>
+          <TableRow
+            key={localRecord.id}
+            hover={isHover}
+            onClick={() => handleRowClick(localRecord)}
+          >
             {React.Children.map(children, (field, index) => (
               <DatagridCell
                 key={`${localRecord.id}-${

--- a/src/common/components/localDataGrid/LocalDataGrid.tsx
+++ b/src/common/components/localDataGrid/LocalDataGrid.tsx
@@ -63,6 +63,7 @@ const LocalDataGrid = ({
             key={localRecord.id}
             hover={isHover}
             onClick={() => handleRowClick(localRecord)}
+            className={rowClick ? classes.clickableRow : undefined}
           >
             {React.Children.map(children, (field, index) => (
               <DatagridCell

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -102,6 +102,9 @@
       "numOfOccurrences": {
         "label": "Occcurences"
       },
+      "numOfEnrolments": {
+        "label": "Enrolments"
+      },
       "occurrences": {
         "label": "Occurrences"
       },

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -102,6 +102,9 @@
       "numOfOccurrences": {
         "label": "Esiintymiä"
       },
+      "numOfEnrolments": {
+        "label": "Ilmoittautuneita"
+      },
       "occurrences": {
         "label": "Esiintymät"
       },

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -19,3 +19,7 @@ export function toShortDateTimeString(date: Date, locale?: string) {
 
   return dateTimeString;
 }
+
+export function sum(numbers: number[]): number {
+  return numbers.reduce((sum: number, capacity: number) => sum + capacity, 0);
+}

--- a/src/domain/eventGroups/api/eventGroupsApi.ts
+++ b/src/domain/eventGroups/api/eventGroupsApi.ts
@@ -1,17 +1,23 @@
-async function getEventGroup() {
-  return {
-    data: {
-      id: '1',
-      name: 'mock event group',
-      events: [
-        {
-          id: '123',
-          name: 'mock event',
-          participantCount: 13,
-        },
-      ],
-    },
-  };
+import { MethodHandlerParams } from '../../../api/types';
+import { EventGroup_eventGroup_events_edges_node as EventNode } from '../../../api/generatedTypes/EventGroup';
+import { queryHandler, handleApiNode } from '../../../api/utils/apiUtils';
+import RelayList from '../../../api/relayList';
+import { eventGroupQuery } from '../queries/EvenGroupQueries';
+
+const EvenList = RelayList<EventNode>();
+
+async function getEventGroup(params: MethodHandlerParams) {
+  const response = await queryHandler({
+    query: eventGroupQuery,
+    variables: { id: params.id },
+  });
+
+  const eventGroup = response.data.eventGroup;
+
+  return handleApiNode({
+    ...eventGroup,
+    events: EvenList(eventGroup.events).items,
+  });
 }
 
 async function addEventGroup() {

--- a/src/domain/eventGroups/detail/EventGroupsDetail.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetail.tsx
@@ -47,7 +47,12 @@ const EventGroupsDetailActions = ({ data, basePath }: any) => {
 };
 
 const EventGroupsDetail = (props: ResourceComponentPropsWithId) => {
+  const { history } = props;
   const t = useTranslate();
+
+  const handleRowClick = (record?: Record) => {
+    history?.push(`/events/${record?.id}/show`);
+  };
 
   return (
     <KukkuuDetailPage
@@ -62,7 +67,7 @@ const EventGroupsDetail = (props: ResourceComponentPropsWithId) => {
         },
       ]}
     >
-      <LocalDataGrid source="events">
+      <LocalDataGrid source="events" rowClick={handleRowClick}>
         <TextField source="name" label={t('events.fields.name.label')} />
         <SelectField
           source="participantsPerInvite"

--- a/src/domain/eventGroups/detail/EventGroupsDetail.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetail.tsx
@@ -7,12 +7,16 @@ import {
   EditButton,
   TextField,
   NumberField,
+  SelectField,
+  FunctionField,
+  Record,
 } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 
 import KukkuuPageLayout from '../../application/layout/kukkuuPageLayout/KukkuuPageLayout';
 import KukkuuDetailPage from '../../application/layout/kukkuuDetailPage/KukkuuDetailPage';
 import LocalDataGrid from '../../../common/components/localDataGrid/LocalDataGrid';
+import { participantsPerInviteChoices } from '../../events/choices';
 import PublishEventGroupButton from './PublishEventGroupButton';
 
 const useStyles = makeStyles((theme) => ({
@@ -57,8 +61,41 @@ const EventGroupsDetail = (props: ResourceComponentPropsWithId) => {
       ]}
     >
       <LocalDataGrid source="events">
-        <TextField source="name" label="Name" />
-        <NumberField source="participantCount" label="Participant Count" />
+        <TextField source="name" label={t('events.fields.name.label')} />
+        <SelectField
+          source="participantsPerInvite"
+          label={t('events.fields.participantsPerInvite.label')}
+          choices={participantsPerInviteChoices}
+        />
+        <NumberField
+          source="duration"
+          label={t('events.fields.duration.label')}
+        />
+        <FunctionField
+          label="events.fields.totalCapacity.label"
+          textAlign="right"
+          render={(record?: Record) =>
+            `${
+              (record?.capacityPerOccurrence || 0) *
+              (record?.occurrences.edges.length || 0)
+            }`
+          }
+        />
+        <NumberField
+          source="occurrences.edges.length"
+          label="events.fields.numOfOccurrences.label"
+        />
+        <FunctionField
+          label="events.fields.numOfEnrolments.label"
+          textAlign="right"
+          render={(record?: Record) =>
+            record?.occurrences.edges.reduce(
+              (sum: number, { node: { enrolmentCount = 0 } }) =>
+                sum + enrolmentCount,
+              0
+            )
+          }
+        />
       </LocalDataGrid>
     </KukkuuDetailPage>
   );

--- a/src/domain/eventGroups/detail/EventGroupsDetail.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetail.tsx
@@ -13,10 +13,12 @@ import {
 } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 
+import { EventGroup_eventGroup_events_edges_node as EventNode } from '../../../api/generatedTypes/EventGroup';
 import KukkuuPageLayout from '../../application/layout/kukkuuPageLayout/KukkuuPageLayout';
 import KukkuuDetailPage from '../../application/layout/kukkuuDetailPage/KukkuuDetailPage';
 import LocalDataGrid from '../../../common/components/localDataGrid/LocalDataGrid';
 import { participantsPerInviteChoices } from '../../events/choices';
+import { countCapacity, countEnrollments } from '../../events/utils';
 import PublishEventGroupButton from './PublishEventGroupButton';
 
 const useStyles = makeStyles((theme) => ({
@@ -74,12 +76,7 @@ const EventGroupsDetail = (props: ResourceComponentPropsWithId) => {
         <FunctionField
           label="events.fields.totalCapacity.label"
           textAlign="right"
-          render={(record?: Record) =>
-            `${
-              (record?.capacityPerOccurrence || 0) *
-              (record?.occurrences.edges.length || 0)
-            }`
-          }
+          render={(record?: Record) => countCapacity(record as EventNode)}
         />
         <NumberField
           source="occurrences.edges.length"
@@ -88,13 +85,7 @@ const EventGroupsDetail = (props: ResourceComponentPropsWithId) => {
         <FunctionField
           label="events.fields.numOfEnrolments.label"
           textAlign="right"
-          render={(record?: Record) =>
-            record?.occurrences.edges.reduce(
-              (sum: number, { node: { enrolmentCount = 0 } }) =>
-                sum + enrolmentCount,
-              0
-            )
-          }
+          render={(record?: Record) => countEnrollments(record as EventNode)}
         />
       </LocalDataGrid>
     </KukkuuDetailPage>

--- a/src/domain/eventGroups/queries/EvenGroupQueries.ts
+++ b/src/domain/eventGroups/queries/EvenGroupQueries.ts
@@ -1,0 +1,40 @@
+import { gql } from '@apollo/client';
+
+const EventGroupEventFragment = gql`
+  fragment EventGroupEventFragment on EventNode {
+    id
+    name
+    image
+    participantsPerInvite
+    duration
+    capacityPerOccurrence
+    publishedAt
+    duration
+    occurrences {
+      edges {
+        node {
+          id
+          enrolmentCount
+        }
+      }
+    }
+  }
+`;
+
+export const eventGroupQuery = gql`
+  query EventGroup($id: ID!) {
+    eventGroup(id: $id) {
+      id
+      name
+      events {
+        edges {
+          node {
+            ...EventGroupEventFragment
+          }
+        }
+      }
+    }
+  }
+
+  ${EventGroupEventFragment}
+`;

--- a/src/domain/events/__tests__/utils.test.js
+++ b/src/domain/events/__tests__/utils.test.js
@@ -1,0 +1,63 @@
+import { countCapacity, countEnrollments, countOccurrences } from '../utils';
+
+describe('event utils', () => {
+  describe('countCapacity', () => {
+    const mockEvent = {
+      capacityPerOccurrence: 5,
+      occurrences: {
+        edges: [null, null, null],
+      },
+    };
+
+    it('should return the capacity for an event', () => {
+      expect(countCapacity(mockEvent)).toEqual(15);
+    });
+
+    it('should return the capacity for many events', () => {
+      expect(countCapacity(mockEvent, mockEvent)).toEqual(30);
+    });
+  });
+
+  describe('countOccurrences', () => {
+    const mockEvent = {
+      occurrences: {
+        edges: [null, null, null],
+      },
+    };
+
+    it('should return the count of occurrences for an event', () => {
+      expect(countOccurrences(mockEvent)).toEqual(3);
+    });
+
+    it('should return the count of occurrences for many events', () => {
+      expect(countOccurrences(mockEvent, mockEvent)).toEqual(6);
+    });
+  });
+
+  describe('countEnrollments', () => {
+    const mockEvent = {
+      occurrences: {
+        edges: [
+          {
+            node: {
+              enrolmentCount: 4,
+            },
+          },
+          {
+            node: {
+              enrolmentCount: 3,
+            },
+          },
+        ],
+      },
+    };
+
+    it('should return the count of enrollments for an event', () => {
+      expect(countEnrollments(mockEvent)).toEqual(7);
+    });
+
+    it('should return the count of enrollments for many events', () => {
+      expect(countEnrollments(mockEvent, mockEvent)).toEqual(14);
+    });
+  });
+});

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -1,0 +1,56 @@
+import { sum } from '../../common/utils';
+
+// Using minimum types so that events of different compositions can be
+// used with the utility, but to the kind of events that don't include
+// the relevant fields.
+
+type CapacityEventNode = {
+  capacityPerOccurrence: number;
+  occurrences: {
+    edges: Array<unknown>;
+  };
+};
+
+export function countCapacity(...events: CapacityEventNode[]): number {
+  return sum(
+    events.map(
+      ({ capacityPerOccurrence, occurrences }: CapacityEventNode) =>
+        capacityPerOccurrence * occurrences.edges.length
+    )
+  );
+}
+
+type CountEventNode = {
+  occurrences: {
+    edges: Array<unknown>;
+  };
+};
+
+export function countOccurrences(...events: CountEventNode[]): number {
+  return sum(
+    events.map(({ occurrences }: CountEventNode) => occurrences.edges.length)
+  );
+}
+
+type EnrollmentsCountEventNode = {
+  occurrences: {
+    edges: (null | {
+      node: {
+        enrolmentCount: number;
+      } | null;
+    })[];
+  };
+};
+
+export function countEnrollments(
+  ...events: EnrollmentsCountEventNode[]
+): number {
+  return sum(
+    events.map((event) =>
+      event.occurrences.edges.reduce(
+        (sum: number, edge) => sum + (edge?.node?.enrolmentCount ?? 0),
+        0
+      )
+    )
+  );
+}

--- a/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
+++ b/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
@@ -21,6 +21,7 @@ import RelayList from '../../../api/relayList';
 import { toDateTimeString } from '../../../common/utils';
 import PublishedField from '../../../common/components/publishedField/PublishedField';
 import KukkuuListPage from '../../application/layout/kukkuuListPage/KukkuuListPage';
+import { countCapacity, countOccurrences } from '../../events/utils';
 
 const useEventsAndEventGroupsListToolbarStyles = makeStyles((theme) => ({
   toolbar: {
@@ -51,25 +52,6 @@ const EventsAndEventGroupsListToolbar = ({ data }: any) => {
 };
 
 const EvenList = RelayList<EventNode>();
-
-function sum(numbers: number[]): number {
-  return numbers.reduce((sum: number, capacity: number) => sum + capacity, 0);
-}
-
-function countCapacity(...events: EventNode[]): number {
-  return sum(
-    events.map(
-      ({ capacityPerOccurrence, occurrences }: EventNode) =>
-        capacityPerOccurrence * occurrences.edges.length
-    )
-  );
-}
-
-function countOccurrences(...events: EventNode[]): number {
-  return sum(
-    events.map(({ occurrences }: EventNode) => occurrences.edges.length)
-  );
-}
 
 function when(
   record: EventOrEventGroupNode,


### PR DESCRIPTION
## Description

Implements the event group detail view. The API is now integrated into the actual API and the event list displays the correct fields.

## Context

[KK-634](https://helsinkisolutionoffice.atlassian.net/browse/KK-634)

## How Has This Been Tested?

I've added some unit tests for utils and an e2e tests for the story this task is developed for.

## Manual Testing Instructions for Reviewers

As a logged in user

1. Navigate to some event group (from the event list)
1. Expect to see the expected fields (name, participants per invite, duration, capacity, occurrence count, enrolment count)
1. Expect to see events that belong to that event group