### PR TITLE
KK-632 | Add view for adding events into event group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Breadcrumbs to event and event group views
 - Event group creation view
 - Event group editing view
+- View for adding an event to an event group
 
 ### Changed
 

--- a/browser-tests/pages/eventGroups.ts
+++ b/browser-tests/pages/eventGroups.ts
@@ -7,6 +7,11 @@ export const eventGroupsDetailPage = {
   eventList: Selector('.MuiTableBody-root'),
   breadcrumbs: Selector('.MuiBreadcrumbs-ol .MuiBreadcrumbs-li a'),
   editButton: screen.getByRole('button', { name: 'Muokkaa' }),
+  addEventToEventGroupButton: screen.getByRole('button', {
+    name: 'Lisää tapahtuma',
+  }),
+  getEventGroup: (name: string) =>
+    Selector('.MuiTableBody-root tr td:first-child').withExactText(name),
 };
 
 export const eventGroupsCreatePage = {

--- a/browser-tests/pages/events.ts
+++ b/browser-tests/pages/events.ts
@@ -1,6 +1,8 @@
 import { Selector } from 'testcafe';
 import { screen } from '@testing-library/testcafe';
 
+import { selectOption } from './select';
+
 export const eventsListPage = {
   title: Selector('h1').withExactText('Tapahtumat'),
   listBody: Selector('.MuiTableBody-root'),
@@ -15,3 +17,32 @@ export const eventsListPage = {
 export const eventsDetailPage = {
   breadcrumbs: Selector('.MuiBreadcrumbs-ol .MuiBreadcrumbs-li a'),
 };
+
+export const eventsCreatePage = {
+  title: Selector('h1').withExactText('Luo tapahtuma'),
+  nameInput: screen.getByLabelText('Nimi *'),
+  participantsPerInviteSelect: screen.getByLabelText(
+    'Osallistujat kutsua kohden *'
+  ),
+  capacityPerOccurrence: screen.getByLabelText('Esiintymän kapasiteetti *'),
+  submitButton: screen.getByRole('button', { name: 'Tallenna' }),
+};
+
+type CreateEvent = {
+  name: string;
+  participantsPerInvite: string;
+  capacityPerOccurrence: number;
+};
+
+export async function fillCreationForm(t: TestController, event: CreateEvent) {
+  await t.typeText(eventsCreatePage.nameInput, event.name);
+  await selectOption(
+    t,
+    eventsCreatePage.participantsPerInviteSelect,
+    event.participantsPerInvite
+  );
+  await t.typeText(
+    eventsCreatePage.capacityPerOccurrence,
+    event.capacityPerOccurrence.toString()
+  );
+}

--- a/browser-tests/pages/select.ts
+++ b/browser-tests/pages/select.ts
@@ -1,0 +1,9 @@
+import { screen } from '@testing-library/testcafe';
+
+export function selectOption(
+  t: TestController,
+  select: Selector,
+  value: string
+) {
+  return t.click(select).click(screen.getByRole('option', { name: value }));
+}

--- a/src/domain/eventGroups/detail/EventGroupsDetail.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetail.tsx
@@ -37,7 +37,7 @@ const EventGroupsDetailActions = ({ data, basePath }: any) => {
   return (
     <TopToolbar className={classes.toolbar}>
       <CreateButton
-        basePath="events"
+        to={`/events/create?eventGroupId=${data?.id}`}
         label={t('eventGroups.actions.addEvent.do')}
       />
       <EditButton basePath="/event-groups" record={data} />

--- a/src/domain/events/create/EventCreate.tsx
+++ b/src/domain/events/create/EventCreate.tsx
@@ -1,17 +1,19 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
-  Create,
   TextInput,
   SimpleForm,
   SelectInput,
   NumberInput,
   required,
   useTranslate,
+  ReactAdminComponentProps,
 } from 'react-admin';
-import { CardHeader, Grid } from '@material-ui/core';
 
-import LanguageTabs from '../../../common/components/languageTab/LanguageTabs';
 import { Language } from '../../../api/generatedTypes/globalTypes';
+import ImageUploadField from '../../../common/components/imageField/ImageUploadField';
+import Aside from '../../../common/components/aside/Aside';
+import useLanguageTabs from '../../../common/hooks/useLanguageTabs';
+import KukkuuCreatePage from '../../application/layout/kukkuuCreatePage/KukkuuCreatePage';
 import {
   validateCapacityPerOccurrence,
   validateDuration,
@@ -20,98 +22,110 @@ import {
   validateShortDescription,
 } from '../validations';
 import { participantsPerInviteChoices } from '../choices';
-import ImageUploadField from '../../../common/components/imageField/ImageUploadField';
-import Aside from '../../../common/components/aside/Aside';
 
-const EventCreate = (props: any) => {
+const EventCreate = (props: ReactAdminComponentProps) => {
+  const { location } = props;
+  const eventGroupId = new URLSearchParams(location?.search).get(
+    'eventGroupId'
+  );
   const translate = useTranslate();
-  const [selectedLanguage, selectLanguage] = useState(Language.FI);
-  const translation = `translations.${selectedLanguage}`;
+  const [
+    languageTabsComponent,
+    translatableField,
+    selectedLanguage,
+  ] = useLanguageTabs();
+
+  const transform = (data: any) => {
+    return {
+      ...data,
+      eventGroupId,
+    };
+  };
+
+  const isAddingEventToEventGroup = Boolean(eventGroupId);
+  const redirect = isAddingEventToEventGroup
+    ? `/event-groups/${eventGroupId}/show`
+    : 'show';
 
   return (
-    <>
-      <CardHeader title={translate('events.create.title')} />
-      <Grid container direction="column" xs={6} item={true}>
-        <Create
-          title="events.create.title"
-          aside={<Aside content="events.create.aside.content" />}
-          {...props}
-        >
-          <SimpleForm
-            variant="outlined"
-            redirect="show"
-            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-            // @ts-ignore
-            validate={validateEvent}
-          >
-            <LanguageTabs
-              selectedLanguage={selectedLanguage}
-              onSelect={selectLanguage}
-            />
-            <ImageUploadField
-              edit={true}
-              source="image"
-              image="image"
-              helperText="events.fields.image.helperText"
-            />
-            <TextInput
-              source={`${translation}.imageAltText`}
-              label="events.fields.imageAltText.label"
-              helperText="events.fields.imageAltText.helperText"
-              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-              // @ts-ignore
-              validate={null}
-              fullWidth
-            />
-            <TextInput
-              source={`${translation}.name`}
-              label="events.fields.name.label"
-              // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-              // @ts-ignore
-              validate={selectedLanguage === Language.FI ? required() : null}
-              fullWidth
-            />
-            <TextInput
-              source={`${translation}.shortDescription`}
-              label="events.fields.shortDescription.label"
-              helperText="events.fields.shortDescription.helperText"
-              validate={validateShortDescription}
-              multiline
-              fullWidth
-            />
-            <TextInput
-              source={`${translation}.description`}
-              label="events.fields.description.label"
-              helperText="events.fields.description.helperText"
-              multiline
-              fullWidth
-            />
-            <SelectInput
-              source="participantsPerInvite"
-              label="events.fields.participantsPerInvite.label"
-              helperText="events.fields.participantsPerInvite.helperText"
-              choices={participantsPerInviteChoices}
-              validate={validateParticipantsPerInvite}
-              fullWidth
-            />
-            <NumberInput
-              source="capacityPerOccurrence"
-              label="events.fields.capacityPerOccurrence.label"
-              helperText="events.fields.capacityPerOccurrence.helperText"
-              validate={validateCapacityPerOccurrence}
-              fullWidth
-            />
-            <NumberInput
-              source="duration"
-              label="events.fields.duration.label"
-              helperText="events.fields.duration.helperText"
-              validate={validateDuration}
-              fullWidth
-            />
-          </SimpleForm>
-        </Create>
-      </Grid>
-    </>
+    <KukkuuCreatePage
+      pageTitle={translate('events.create.title')}
+      reactAdminProps={{
+        ...props,
+        aside: <Aside content="events.create.aside.content" />,
+        transform,
+      }}
+    >
+      <SimpleForm
+        variant="outlined"
+        redirect={redirect}
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        validate={validateEvent}
+      >
+        {languageTabsComponent}
+        <ImageUploadField
+          edit={true}
+          source="image"
+          image="image"
+          helperText="events.fields.image.helperText"
+        />
+        <TextInput
+          source={translatableField('imageAltText')}
+          label="events.fields.imageAltText.label"
+          helperText="events.fields.imageAltText.helperText"
+          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+          // @ts-ignore
+          validate={null}
+          fullWidth
+        />
+        <TextInput
+          source={translatableField('name')}
+          label="events.fields.name.label"
+          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+          // @ts-ignore
+          validate={selectedLanguage === Language.FI ? required() : null}
+          fullWidth
+        />
+        <TextInput
+          source={translatableField('shortDescription')}
+          label="events.fields.shortDescription.label"
+          helperText="events.fields.shortDescription.helperText"
+          validate={validateShortDescription}
+          multiline
+          fullWidth
+        />
+        <TextInput
+          source={translatableField('description')}
+          label="events.fields.description.label"
+          helperText="events.fields.description.helperText"
+          multiline
+          fullWidth
+        />
+        <SelectInput
+          source="participantsPerInvite"
+          label="events.fields.participantsPerInvite.label"
+          helperText="events.fields.participantsPerInvite.helperText"
+          choices={participantsPerInviteChoices}
+          validate={validateParticipantsPerInvite}
+          fullWidth
+        />
+        <NumberInput
+          source="capacityPerOccurrence"
+          label="events.fields.capacityPerOccurrence.label"
+          helperText="events.fields.capacityPerOccurrence.helperText"
+          validate={validateCapacityPerOccurrence}
+          fullWidth
+        />
+        <NumberInput
+          source="duration"
+          label="events.fields.duration.label"
+          helperText="events.fields.duration.helperText"
+          validate={validateDuration}
+          fullWidth
+        />
+      </SimpleForm>
+    </KukkuuCreatePage>
   );
 };
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,4 +13,5 @@ export default [
   <Route exact path="/callback" component={CallbackPage} noLayout />,
   <Route exact path="/unauthorized" component={UnauthorizedPage} noLayout />,
   <Redirect exact from="/event-groups" to="/events-and-event-groups" />,
+  <Redirect exact path="/events" to="/events-and-event-groups" />,
 ];


### PR DESCRIPTION
## Description

Refactors the event group creation view so that if an `eventGroupId` is passed to it in query parameters, it will add the created event into the event group of that id and redirect the user to that event group after the event has been created.

This PR also fixes the browser tests that I accidentally broke with a rename in some earlier commit.

## Context

[KK-632](https://helsinkisolutionoffice.atlassian.net/browse/KK-632)

## How Has This Been Tested?

I've added a browser test that test the happy path of the user story.

## Manual Testing Instructions for Reviewers

As a logged in user

1. Go to the details of some event group
1. Press the add event button
1. Fill the event form and submit it
1. Expect to be redirected back to the event group
1. Expect to see the created event in the list of events for the event group