### PR TITLE
KK-616 | Add breadcrumb to occurrence detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Event group creation view
 - Event group editing view
 - View for adding an event to an event group
+- Breadcrumb to occurrence detail view
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,32 @@
   "name": "kukkuu-admin",
   "version": "1.4.0",
   "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "TZ=Europe/Helsinki NODE_ICU_DATA=node_modules/full-icu react-scripts test --env=jsdom-fourteen",
+    "eject": "react-scripts eject",
+    "lint": "eslint --ext js,ts,tsx src",
+    "graphql-types": "apollo client:codegen --target=typescript --no-addTypename --outputFlat src/api/generatedTypes",
+    "update-translations": "fetch-translations 1hmdfJ-iVIqsD4AN2vx2YMMM2BQs-en1xxsX2Vu5_7vY -l fi,en -o ./src/common/translation",
+    "test:browser": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/ --live",
+    "test:browser:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" browser-tests/ -s takeOnFails=true --lang=fi-FI"
+  },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
   "dependencies": {
     "@apollo/client": "^3.2.7",
     "@sentry/browser": "^5.20.0",
@@ -37,37 +63,12 @@
     "react-scripts": "3.4.4",
     "typescript": "~3.9.7"
   },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom-fourteen",
-    "eject": "react-scripts eject",
-    "lint": "eslint --ext js,ts,tsx src",
-    "graphql-types": "apollo client:codegen --target=typescript --no-addTypename --outputFlat src/api/generatedTypes",
-    "update-translations": "fetch-translations 1hmdfJ-iVIqsD4AN2vx2YMMM2BQs-en1xxsX2Vu5_7vY -l fi,en -o ./src/common/translation",
-    "test:browser": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/ --live",
-    "test:browser:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" browser-tests/ -s takeOnFails=true --lang=fi-FI"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
   "devDependencies": {
     "@testing-library/testcafe": "^4.2.3",
     "apollo": "^2.30.1",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "full-icu": "^1.3.1",
     "helsinki-utils": "City-of-Helsinki/helsinki-utils-js.git#0.1.0",
     "jest-localstorage-mock": "^2.4.3",
     "prettier": "2.0.5",

--- a/src/api/generatedTypes/Occurrence.ts
+++ b/src/api/generatedTypes/Occurrence.ts
@@ -9,17 +9,27 @@ import { Language } from "./globalTypes";
 // GraphQL query operation: Occurrence
 // ====================================================
 
+export interface Occurrence_occurrence_event_eventGroup {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+}
+
 export interface Occurrence_occurrence_event {
   /**
    * The ID of the object.
    */
   id: string;
+  name: string | null;
   capacityPerOccurrence: number;
   /**
    * In minutes
    */
   duration: number | null;
   publishedAt: any | null;
+  eventGroup: Occurrence_occurrence_event_eventGroup | null;
 }
 
 export interface Occurrence_occurrence_venue_translations {

--- a/src/api/generatedTypes/OccurrenceFragment.ts
+++ b/src/api/generatedTypes/OccurrenceFragment.ts
@@ -9,17 +9,27 @@ import { Language } from "./globalTypes";
 // GraphQL fragment: OccurrenceFragment
 // ====================================================
 
+export interface OccurrenceFragment_event_eventGroup {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+}
+
 export interface OccurrenceFragment_event {
   /**
    * The ID of the object.
    */
   id: string;
+  name: string | null;
   capacityPerOccurrence: number;
   /**
    * In minutes
    */
   duration: number | null;
   publishedAt: any | null;
+  eventGroup: OccurrenceFragment_event_eventGroup | null;
 }
 
 export interface OccurrenceFragment_venue_translations {

--- a/src/api/generatedTypes/Occurrences.ts
+++ b/src/api/generatedTypes/Occurrences.ts
@@ -9,17 +9,27 @@ import { Language } from "./globalTypes";
 // GraphQL query operation: Occurrences
 // ====================================================
 
+export interface Occurrences_occurrences_edges_node_event_eventGroup {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string | null;
+}
+
 export interface Occurrences_occurrences_edges_node_event {
   /**
    * The ID of the object.
    */
   id: string;
+  name: string | null;
   capacityPerOccurrence: number;
   /**
    * In minutes
    */
   duration: number | null;
   publishedAt: any | null;
+  eventGroup: Occurrences_occurrences_edges_node_event_eventGroup | null;
 }
 
 export interface Occurrences_occurrences_edges_node_venue_translations {

--- a/src/common/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/common/__tests__/__snapshots__/utils.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`common utils date formatters toDateString should return a correctly formatted string 1`] = `"1.1.1970"`;
+
+exports[`common utils date formatters toDateTimeString should return a correctly formatted string 1`] = `"1.1.1970 klo 02.00"`;
+
+exports[`common utils date formatters toShortDateTimeString should return a correctly formatted string 1`] = `"1.1.1970, 02.00"`;
+
+exports[`common utils date formatters toTimeString should return a correctly formatted string 1`] = `"02.00"`;

--- a/src/common/__tests__/utils.test.js
+++ b/src/common/__tests__/utils.test.js
@@ -1,4 +1,11 @@
-import { sum, requireFinnishFields } from '../utils';
+import {
+  sum,
+  requireFinnishFields,
+  toDateTimeString,
+  toShortDateTimeString,
+  toDateString,
+  toTimeString,
+} from '../utils';
 
 describe('common utils', () => {
   describe('sum', () => {
@@ -59,6 +66,22 @@ describe('common utils', () => {
 
       checkErrors(errors, 'name', errorMessage);
       checkErrors(errors, 'description', errorMessage2);
+    });
+  });
+
+  describe('date formatters', () => {
+    const date = new Date(0);
+    const formatters = [
+      toDateTimeString,
+      toShortDateTimeString,
+      toDateString,
+      toTimeString,
+    ];
+
+    formatters.forEach((formatter) => {
+      it(`${formatter.name} should return a correctly formatted string`, () => {
+        expect(formatter(date)).toMatchSnapshot();
+      });
     });
   });
 });

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -3,7 +3,10 @@ import get from 'lodash/get';
 import i18nProvider from './translation/i18nProvider';
 import { Language } from '../api/generatedTypes/globalTypes';
 
-export function toDateTimeString(date: Date, locale?: string) {
+export function toDateTimeString(
+  date: Date,
+  locale: string = i18nProvider.getLocale()
+) {
   return date.toLocaleString(locale, {
     year: 'numeric',
     month: 'numeric',
@@ -13,7 +16,10 @@ export function toDateTimeString(date: Date, locale?: string) {
   });
 }
 
-export function toShortDateTimeString(date: Date, locale?: string) {
+export function toShortDateTimeString(
+  date: Date,
+  locale: string = i18nProvider.getLocale()
+) {
   const dateTimeString = toDateTimeString(date, locale);
 
   if (dateTimeString && locale === 'fi') {
@@ -23,6 +29,23 @@ export function toShortDateTimeString(date: Date, locale?: string) {
   }
 
   return dateTimeString;
+}
+
+export function toDateString(
+  date: Date,
+  locale: string = i18nProvider.getLocale()
+) {
+  return date.toLocaleDateString(locale);
+}
+
+export function toTimeString(
+  date: Date,
+  locale: string = i18nProvider.getLocale()
+) {
+  return date.toLocaleTimeString(locale, {
+    hour: '2-digit',
+    minute: 'numeric',
+  });
 }
 
 export function sum(numbers: number[]): number {

--- a/src/domain/application/layout/kukkuuDetailPage/KukkuuDetailPage.tsx
+++ b/src/domain/application/layout/kukkuuDetailPage/KukkuuDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, ReactElement } from 'react';
+import React, { ComponentType, ReactElement, ReactText } from 'react';
 import { useGetOne, Record, ShowProps } from 'react-admin';
 import omit from 'lodash/omit';
 
@@ -11,6 +11,7 @@ type Props = {
   children: ReactElement;
   reactAdminProps: ShowProps;
   pageTitleSource?: string;
+  pageTitle?: string | ((record?: Record) => ReactText | undefined);
   layout?: ComponentType<KukkuuLayoutProps>;
   breadcrumbs?: ((data?: Record) => Crumb[]) | Crumb[];
 };
@@ -18,6 +19,7 @@ type Props = {
 const KukkuuDetailPage = ({
   children,
   pageTitleSource,
+  pageTitle,
   reactAdminProps,
   layout: Layout = KukkuuCardPageLayout,
   breadcrumbs,
@@ -35,6 +37,7 @@ const KukkuuDetailPage = ({
   return (
     <Layout
       pageTitleSource={pageTitleSource}
+      pageTitle={pageTitle}
       reactAdminProps={reactAdminProps}
       breadcrumbs={crumbs}
     >

--- a/src/domain/children/ChildShow.tsx
+++ b/src/domain/children/ChildShow.tsx
@@ -96,10 +96,7 @@ const ChildShow = (props: any) => {
                 source="node.time"
                 locales={locale}
               />
-              <OccurrenceTimeRangeField
-                occurrenceSource="node"
-                locales={locale}
-              />
+              <OccurrenceTimeRangeField occurrenceSource="node" />
               <ReferenceField
                 label="occurrences.fields.event.label"
                 source="node.event.id"

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -215,10 +215,7 @@ const EventShow = (props: ResourceComponentPropsWithId) => {
                 source="time"
                 locales={locale}
               />
-              <OccurrenceTimeRangeField
-                label="occurrences.fields.time.fields.time.label"
-                locales={locale}
-              />
+              <OccurrenceTimeRangeField label="occurrences.fields.time.fields.time.label" />
               <ReferenceField
                 label="occurrences.fields.venue.label"
                 source="venue.id"

--- a/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
+++ b/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
@@ -2,7 +2,6 @@ import React, { ReactText } from 'react';
 import {
   TextField,
   useTranslate,
-  useLocale,
   NumberField,
   FunctionField,
   Record,
@@ -82,7 +81,6 @@ const useStyles = makeStyles((theme) => ({
 
 const EventsAndEventGroupsList = (props: ReactAdminComponentProps) => {
   const translate = useTranslate();
-  const locale = useLocale();
   const classes = useStyles();
 
   const handleRowClick = (id: ReactText, basePath: string, record: Record) => {
@@ -181,7 +179,7 @@ const EventsAndEventGroupsList = (props: ReactAdminComponentProps) => {
         render={(date: Date) =>
           `${translate(
             'events.fields.publishedAt.published.label'
-          )} ${toDateTimeString(date, locale)}`
+          )} ${toDateTimeString(date)}`
         }
         emptyText={translate('events.fields.publishedAt.values.NOT_PUBLISHED')}
         className={classes.bold}

--- a/src/domain/messages/detail/MessagesDetail.tsx
+++ b/src/domain/messages/detail/MessagesDetail.tsx
@@ -7,7 +7,6 @@ import {
   useTranslate,
   EditButton,
   TopToolbar,
-  useLocale,
   FunctionField,
 } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
@@ -48,7 +47,6 @@ const MessageDetailToolbar = ({
   data,
 }: MessageDetailToolbarProps) => {
   const classes = useMessageDetailsToolbarStyles();
-  const locale = useLocale();
   const t = useTranslate();
 
   const isSent = Boolean(data?.sentAt);
@@ -60,7 +58,7 @@ const MessageDetailToolbar = ({
           <Typography component="span" className={classes.metaTitle}>
             {t('messages.fields.sentAt.sent')}
           </Typography>
-          {` ${toDateTimeString(new Date(data?.sentAt), locale)}`}
+          {` ${toDateTimeString(new Date(data?.sentAt))}`}
         </Typography>
         <Typography className={classes.meta}>
           <Typography component="span" className={classes.metaTitle}>
@@ -119,7 +117,6 @@ const MessagesDetail = (props: ResourceComponentPropsWithId) => {
   const classes = useStyles();
   const [languageTabsComponent, translatableField] = useLanguageTabs();
   const t = useTranslate();
-  const locale = useLocale();
 
   return (
     <KukkuuDetailPage
@@ -157,7 +154,7 @@ const MessagesDetail = (props: ResourceComponentPropsWithId) => {
             const stringifiedRecords =
               record &&
               record.occurrences.edges.map((connection: any) =>
-                toShortDateTimeString(new Date(connection.node.time), locale)
+                toShortDateTimeString(new Date(connection.node.time))
               );
 
             if (stringifiedRecords.length === 0) {

--- a/src/domain/messages/list/MessagesList.tsx
+++ b/src/domain/messages/list/MessagesList.tsx
@@ -4,7 +4,6 @@ import {
   useTranslate,
   TextField,
   SelectField,
-  useLocale,
   FunctionField,
 } from 'react-admin';
 import { get } from 'lodash';
@@ -17,7 +16,6 @@ import styles from './messageList.module.css';
 
 const MessagesList = (props: ResourceComponentPropsWithId) => {
   const t = useTranslate();
-  const locale = useLocale();
 
   return (
     <KukkuuListPage
@@ -61,10 +59,7 @@ const MessagesList = (props: ResourceComponentPropsWithId) => {
         label={t('messages.fields.sentAt.label')}
         source="sentAt"
         render={(date: Date) =>
-          `${t('messages.fields.sentAt.sent')} ${toDateTimeString(
-            date,
-            locale
-          )}`
+          `${t('messages.fields.sentAt.sent')} ${toDateTimeString(date)}`
         }
         emptyText={t('messages.fields.sentAt.notSent')}
         className={styles.bold}

--- a/src/domain/occurrences/Occurrence.ts
+++ b/src/domain/occurrences/Occurrence.ts
@@ -1,0 +1,56 @@
+import { toDateTimeString, toTimeString } from '../../common/utils';
+import i18nProvider from '../../common/translation/i18nProvider';
+
+type OccurrenceType = {
+  time: string;
+  event: {
+    duration: number | null;
+  };
+};
+
+class Occurrence {
+  occurrence: OccurrenceType;
+
+  constructor(occurrence: OccurrenceType) {
+    this.occurrence = occurrence;
+  }
+
+  get time() {
+    return toDateTimeString(new Date(this.occurrence.time));
+  }
+
+  get startTime() {
+    return toTimeString(new Date(this.occurrence.time));
+  }
+
+  get endTime() {
+    const duration = this.occurrence.event.duration; // minutes
+
+    if (!duration) {
+      return null;
+    }
+
+    const startTime = new Date(this.occurrence.time);
+    const endTime = new Date(startTime.getTime() + 60000 * duration);
+
+    return toTimeString(endTime);
+  }
+
+  get duration() {
+    return `${this.startTime} - ${this.endTime}`;
+  }
+
+  get occurrenceDateAndDuration() {
+    return `${this.time} - ${this.endTime}`;
+  }
+
+  get title() {
+    const translatedResourceName = i18nProvider.translate(
+      'occurrences.show.title'
+    );
+
+    return `${translatedResourceName} ${this.occurrenceDateAndDuration}`;
+  }
+}
+
+export default Occurrence;

--- a/src/domain/occurrences/OccurrenceArraySelect.tsx
+++ b/src/domain/occurrences/OccurrenceArraySelect.tsx
@@ -2,7 +2,6 @@ import React, { ChangeEvent } from 'react';
 import {
   SelectArrayInput,
   ReferenceArrayInput,
-  useLocale,
   useTranslate,
 } from 'react-admin';
 import { useField, useForm } from 'react-final-form';
@@ -41,7 +40,6 @@ type Props = Omit<ReferenceArrayInputProps, 'children' | 'reference'> & {
 };
 
 const OccurrenceArraySelect = ({ eventId, allText, ...rest }: Props) => {
-  const locale = useLocale();
   const filter = getFilters(eventId);
   const field = useField(rest.source);
   const form = useForm();
@@ -80,7 +78,7 @@ const OccurrenceArraySelect = ({ eventId, allText, ...rest }: Props) => {
   const getChoices = (records: Occurrence[]) => {
     return records.map(({ id, time }) => ({
       id,
-      name: toShortDateTimeString(new Date(time), locale),
+      name: toShortDateTimeString(new Date(time)),
     }));
   };
 

--- a/src/domain/occurrences/OccurrenceShow.tsx
+++ b/src/domain/occurrences/OccurrenceShow.tsx
@@ -13,6 +13,7 @@ import {
   FunctionField,
   useDataProvider,
   useGetOne,
+  Record,
 } from 'react-admin';
 import PropTypes from 'prop-types';
 import Select from '@material-ui/core/Select';
@@ -20,14 +21,16 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import makeStyles from '@material-ui/styles/makeStyles';
 
-import { OccurrenceTimeRangeField } from './fields';
 import {
   Occurrences_occurrences_edges_node_enrolments_edges as EnrolmentEdge,
   Occurrences_occurrences_edges_node_enrolments_edges_node as Enrolment,
   Occurrences_occurrences_edges_node_enrolments_edges_node_child_guardians_edges_node as Guardian,
-  Occurrences_occurrences_edges_node as Occurrence,
+  Occurrences_occurrences_edges_node as OccurrenceType,
 } from '../../api/generatedTypes/Occurrences';
-import KukkuuShow from '../application/layout/kukkuuDetailPage/KukkuuShow';
+import KukkuuPageLayout from '../application/layout/kukkuuPageLayout/KukkuuPageLayout';
+import KukkuuDetailPage from '../application/layout/kukkuuDetailPage/KukkuuDetailPage';
+import { OccurrenceTimeRangeField } from './fields';
+import Occurrence from './Occurrence';
 
 type AttendedFieldProps = {
   record?: EnrolmentEdge;
@@ -138,8 +141,41 @@ const OccurrenceShow = (props: any) => {
     );
   };
 
+  const getBreadCrumbs = (record?: Record) => {
+    const crumbs = [
+      {
+        label: translate('events.list.title'),
+        link: '/events-and-event-groups',
+      },
+    ];
+
+    const eventGroup = record?.event?.eventGroup;
+    const event = record?.event;
+
+    if (eventGroup) {
+      crumbs.push({
+        label: eventGroup?.name,
+        link: `/event-groups/${eventGroup?.id}/show`,
+      });
+    }
+
+    crumbs.push({
+      label: event?.name,
+      link: `/events/${event?.id}/show`,
+    });
+
+    return crumbs;
+  };
+
   return (
-    <KukkuuShow {...props} title="occurrences.show.title">
+    <KukkuuDetailPage
+      reactAdminProps={props}
+      layout={KukkuuPageLayout}
+      pageTitle={(record) =>
+        record && new Occurrence(record as OccurrenceType).title
+      }
+      breadcrumbs={getBreadCrumbs}
+    >
       <SimpleShowLayout>
         <ReferenceField
           label="occurrences.fields.event.label"
@@ -154,7 +190,7 @@ const OccurrenceShow = (props: any) => {
           source="time"
           locales={locale}
         />
-        <OccurrenceTimeRangeField locales={locale} />
+        <OccurrenceTimeRangeField />
         <ReferenceField
           label="occurrences.fields.venue.label"
           source="venue.id"
@@ -170,7 +206,7 @@ const OccurrenceShow = (props: any) => {
         <FunctionField
           // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
           // @ts-ignore
-          render={(occurrence: Occurrence) =>
+          render={(occurrence: OccurrenceType) =>
             occurrence.freeSpotNotificationSubscriptions?.edges.length || '0'
           }
           label="occurrences.fields.freeSpotNotificationSubscriptions.label"
@@ -222,7 +258,7 @@ const OccurrenceShow = (props: any) => {
           </Datagrid>
         </ArrayField>
       </SimpleShowLayout>
-    </KukkuuShow>
+    </KukkuuDetailPage>
   );
 };
 

--- a/src/domain/occurrences/fields.tsx
+++ b/src/domain/occurrences/fields.tsx
@@ -2,35 +2,28 @@ import get from 'lodash/get';
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-import { Occurrences_occurrences_edges_node as Occurrence } from '../../api/generatedTypes/Occurrences';
+import { Occurrences_occurrences_edges_node as OccurrenceType } from '../../api/generatedTypes/Occurrences';
+import Occurrence from './Occurrence';
 
 export const OccurrenceTimeRangeField = ({
   record,
-  locales,
   occurrenceSource,
 }: {
-  [key: string]: any;
-  record?: Occurrence;
+  record?: OccurrenceType;
   occurrenceSource?: string;
 }) => {
   if (!record) {
     return null;
   }
-  const options = {
-    hour: '2-digit',
-    minute: 'numeric',
-  };
-  const occurrence = occurrenceSource ? get(record, occurrenceSource) : record;
-  const start = new Date(Date.parse(occurrence.time));
-  const startString = start.toLocaleString(locales, options);
-  const duration = occurrence.event.duration;
+
+  const occurrenceData = occurrenceSource
+    ? get(record, occurrenceSource)
+    : record;
+  const occurrence = new Occurrence(occurrenceData);
+
   return (
     <Typography variant="body2" component="span">
-      {duration
-        ? `${startString} – ${new Date(
-            start.getTime() + 60000 * duration
-          ).toLocaleString(locales, options)}`
-        : startString}
+      {occurrence.duration ? occurrence.duration : occurrence.startTime}
     </Typography>
   );
 };

--- a/src/domain/occurrences/queries/OccurrenceQueries.ts
+++ b/src/domain/occurrences/queries/OccurrenceQueries.ts
@@ -8,9 +8,14 @@ const OccurrenceShowPage = {
         time
         event {
           id
+          name
           capacityPerOccurrence
           duration
           publishedAt
+          eventGroup {
+            id
+            name
+          }
         }
         enrolmentCount
         capacity

--- a/yarn.lock
+++ b/yarn.lock
@@ -7149,6 +7149,11 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+full-icu@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.3.1.tgz#e67fdf58523f1d1e0d9143b1542fe2024c1c8997"
+  integrity sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
## Description

I hadn't noticed that the breadcrumb was supposed to work in the Occurrence detail view as well. This PR implements breadcrumbs in the occurrence details view

## Context

[KK-616](https://helsinkisolutionoffice.atlassian.net/browse/KK-616)

## How Has This Been Tested?

This has been tested manually. I've checked that occurrences with and without an event group appear correct.

## Manual Testing Instructions for Reviewers

As a logged in user

1. Go to event list
1. Select event grouo
1. Select event
1. Select occurrence
1. Expect to see a breadcrumb