### PR TITLE
KK-633 | Add event group publish button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Event group editing view
 - View for adding an event to an event group
 - Breadcrumb to occurrence detail view
+- Event group publish button
 
 ### Changed
 

--- a/browser-tests/eventFeature.ts
+++ b/browser-tests/eventFeature.ts
@@ -7,6 +7,7 @@ import {
   eventsDetailPage,
   eventsEditPage,
   fillCreationForm,
+  deleteEvent,
 } from './pages/events';
 
 function buildEvent(overrides: any = {}) {
@@ -59,11 +60,7 @@ test('As an admin I want to be able to create, update and delete events', async 
   // Assert that we have been redirected to the events details
   await t.expect(eventsDetailPage.title(updateEvent.name).exists).ok();
 
-  // Go to edit view
-  await t.click(eventsDetailPage.editButton);
-
-  // Delete the event
-  await t.click(eventsEditPage.deleteButton);
+  await deleteEvent(t);
 
   // Assert that we have been redirected to the events list
   await t.expect(eventsListPage.title.exists).ok();

--- a/browser-tests/eventFeature.ts
+++ b/browser-tests/eventFeature.ts
@@ -1,0 +1,74 @@
+import { routes } from './pages/routes';
+import { login } from './utils/login';
+import { navigation } from './pages/navigation';
+import {
+  eventsListPage,
+  eventsCreatePage,
+  eventsDetailPage,
+  eventsEditPage,
+  fillCreationForm,
+} from './pages/events';
+
+function buildEvent(overrides: any = {}) {
+  return {
+    name: `Browser test: event feature ${new Date().toLocaleDateString()}`,
+    participantsPerInvite: 'Perhe',
+    capacityPerOccurrence: 5,
+    ...overrides,
+  };
+}
+
+fixture`Events feature`
+  .page(routes.eventsList())
+  .beforeEach(async (t) => {
+    await login(t);
+    await t.click(navigation.events);
+
+    t.ctx.createEvent = buildEvent();
+    t.ctx.updateEvent = buildEvent({
+      name: `Browser test: event feature (updated) ${new Date().toLocaleDateString()}`,
+    });
+  })
+  .afterEach(async (t) => {
+    delete t.ctx.createEvent;
+    delete t.ctx.updateEvent;
+  });
+
+test('As an admin I want to be able to create, update and delete events', async (t) => {
+  const { updateEvent, createEvent } = t.ctx;
+
+  // Go to creation form
+  await t.click(eventsListPage.createEventButton);
+
+  // Fill the form and submit it
+  await fillCreationForm(t, createEvent);
+  await t.click(eventsCreatePage.submitButton);
+
+  // Assert that we have been redirected to the events details
+  await t.expect(eventsDetailPage.title(createEvent.name).exists).ok();
+
+  // Go to edit view
+  await t.click(eventsDetailPage.editButton);
+
+  // Edit short description and save
+  await t
+    .selectText(eventsEditPage.nameInput)
+    .typeText(eventsEditPage.nameInput, updateEvent.name)
+    .click(eventsEditPage.submitButton);
+
+  // Assert that we have been redirected to the events details
+  await t.expect(eventsDetailPage.title(updateEvent.name).exists).ok();
+
+  // Go to edit view
+  await t.click(eventsDetailPage.editButton);
+
+  // Delete the event
+  await t.click(eventsEditPage.deleteButton);
+
+  // Assert that we have been redirected to the events list
+  await t.expect(eventsListPage.title.exists).ok();
+  // And that the event no longer exists
+  await t
+    .expect(eventsListPage.eventOrEventGroupByName(updateEvent.name).exists)
+    .notOk();
+});

--- a/browser-tests/eventGroupsFeature.ts
+++ b/browser-tests/eventGroupsFeature.ts
@@ -180,7 +180,7 @@ test('As an admin I want to be able to add events to an event group', async (t) 
   await deleteEvent(t);
 });
 
-test('As an admin I wan to be able to publish an event group', async (t) => {
+test('As an admin I want to be able to publish an event group', async (t) => {
   const { publishEventGroup } = t.ctx;
 
   await createEventGroup(t, publishEventGroup);

--- a/browser-tests/messageFeature.ts
+++ b/browser-tests/messageFeature.ts
@@ -36,7 +36,7 @@ fixture`Messages feature`
     delete t.ctx.message;
   });
 
-test('As a user I can see a list of messages', async (t) => {
+test('As an admin I want see a list of messages', async (t) => {
   // The list displays the expected fields
   await t
     .expect(messagesListPage.listHeader.filter(includesHeaders).exists)
@@ -46,7 +46,7 @@ test('As a user I can see a list of messages', async (t) => {
   await t.expect(messagesListPage.listBody.childElementCount).gt(0);
 });
 
-test('As a user I can create and delete messages', async (t) => {
+test('As an admin I want to create and delete messages', async (t) => {
   // From message list view go into create message view
   await t.click(messagesListPage.createMessageLink);
 

--- a/browser-tests/pages/eventGroups.ts
+++ b/browser-tests/pages/eventGroups.ts
@@ -1,6 +1,8 @@
 import { Selector } from 'testcafe';
 import { screen } from '@testing-library/testcafe';
 
+import { eventsListPage } from './events';
+
 export const eventGroupsDetailPage = {
   title: Selector('h1'),
   eventListHeader: Selector('.MuiTableHead-root > .MuiTableRow-root'),
@@ -10,8 +12,12 @@ export const eventGroupsDetailPage = {
   addEventToEventGroupButton: screen.getByRole('button', {
     name: 'Lisää tapahtuma',
   }),
-  getEventGroup: (name: string) =>
+  getEvent: (name: string) =>
     Selector('.MuiTableBody-root tr td:first-child').withExactText(name),
+  publishButton: screen.queryByRole('button', {
+    name: 'Julkaise tapahtumaryhmä',
+  }),
+  publishConfirmButton: screen.getByRole('button', { name: 'Vahvista' }),
 };
 
 export const eventGroupsCreatePage = {
@@ -27,3 +33,44 @@ export const eventGroupsEditPage = {
   deleteButton: screen.getByRole('button', { name: 'Poista' }),
   confirmDeleteButton: screen.getByRole('button', { name: 'Vahvista' }),
 };
+
+type CreateEventGroup = {
+  name: string;
+  shortDescription: string;
+  description: string;
+};
+
+export async function fillCreationForm(
+  t: TestController,
+  values: CreateEventGroup
+) {
+  await t
+    .typeText(eventGroupsCreatePage.nameInput, values.name)
+    .typeText(
+      eventGroupsCreatePage.shortDescriptionInput,
+      values.shortDescription
+    )
+    .typeText(eventGroupsCreatePage.descriptionInput, values.description);
+}
+
+export async function createEventGroup(
+  t: TestController,
+  values: CreateEventGroup
+) {
+  // From event list go to event group creation form
+  await t.click(eventsListPage.createEventGroupButton);
+
+  // Fill the form and submit it
+  await fillCreationForm(t, values);
+  await t.click(eventGroupsCreatePage.submitButton);
+}
+
+export async function deleteEventGroup(t: TestController) {
+  // From event group details go to edit view
+  await t.click(eventGroupsDetailPage.editButton);
+
+  // Delete event group
+  await t
+    .click(eventGroupsEditPage.deleteButton)
+    .click(eventGroupsEditPage.confirmDeleteButton);
+}

--- a/browser-tests/pages/events.ts
+++ b/browser-tests/pages/events.ts
@@ -12,20 +12,36 @@ export const eventsListPage = {
   createEventGroupButton: screen.getByRole('button', {
     name: 'Uusi tapahtumaryhmä',
   }),
+  createEventButton: screen.getByRole('button', {
+    name: 'Uusi tapahtuma',
+  }),
 };
 
 export const eventsDetailPage = {
   breadcrumbs: Selector('.MuiBreadcrumbs-ol .MuiBreadcrumbs-li a'),
+  editButton: screen.getByRole('button', {
+    name: 'Muokkaa',
+  }),
+  title: (name: string) => Selector('h1'),
 };
 
-export const eventsCreatePage = {
-  title: Selector('h1').withExactText('Luo tapahtuma'),
+const eventForm = {
   nameInput: screen.getByLabelText('Nimi *'),
   participantsPerInviteSelect: screen.getByLabelText(
     'Osallistujat kutsua kohden *'
   ),
   capacityPerOccurrence: screen.getByLabelText('Esiintymän kapasiteetti *'),
   submitButton: screen.getByRole('button', { name: 'Tallenna' }),
+};
+
+export const eventsCreatePage = {
+  title: Selector('h1').withExactText('Luo tapahtuma'),
+  ...eventForm,
+};
+
+export const eventsEditPage = {
+  ...eventForm,
+  deleteButton: screen.getAllByRole('button', { name: 'Poista' }).nth(1),
 };
 
 type CreateEvent = {

--- a/browser-tests/pages/events.ts
+++ b/browser-tests/pages/events.ts
@@ -7,7 +7,7 @@ export const eventsListPage = {
   title: Selector('h1').withExactText('Tapahtumat'),
   listBody: Selector('.MuiTableBody-root'),
   anyEventGroup: Selector('.MuiTableBody-root tr').withText('TAPAHTUMARYHMÄ'),
-  eventOrEventGroupByName: (name) =>
+  eventOrEventGroupByName: (name: string) =>
     Selector('.MuiTableBody-root tr td:first-child').withExactText(name),
   createEventGroupButton: screen.getByRole('button', {
     name: 'Uusi tapahtumaryhmä',
@@ -61,4 +61,12 @@ export async function fillCreationForm(t: TestController, event: CreateEvent) {
     eventsCreatePage.capacityPerOccurrence,
     event.capacityPerOccurrence.toString()
   );
+}
+
+export async function deleteEvent(t: TestController) {
+  // Go to edit view
+  await t.click(eventsDetailPage.editButton);
+
+  // Delete the event
+  await t.click(eventsEditPage.deleteButton);
 }

--- a/src/api/__tests__/client.tests.js
+++ b/src/api/__tests__/client.tests.js
@@ -1,0 +1,174 @@
+import * as Sentry from '@sentry/browser';
+
+import Config from '../../domain/config';
+import { handleError } from '../client';
+
+const graphQLError = {
+  message: 'Message',
+  extensions: {
+    code: 'TEST',
+  },
+  locations: [],
+  path: ['myTest'],
+};
+
+const operation = {
+  operationName: 'Test',
+  query: {
+    definitions: [
+      {
+        kind: 'OperationDefinition',
+        operation: 'query',
+      },
+    ],
+  },
+};
+
+describe('client', () => {
+  describe('handleError', () => {
+    const mockScope = {
+      setLevel: jest.fn(),
+      setTag: jest.fn(),
+      setContext: jest.fn(),
+      setExtra: jest.fn(),
+    };
+
+    beforeAll(() => {
+      jest.spyOn(console, 'error').mockImplementation(() => {
+        // pass
+      });
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    describe('GraphQL errors', () => {
+      it('should send graphQL errors', () => {
+        const captureExceptionSpy = jest.spyOn(Sentry, 'captureException');
+        const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
+        const withScopeSpy = jest.spyOn(Sentry, 'withScope');
+
+        withScopeSpy.mockImplementation((cb) => cb(mockScope));
+
+        handleError({ graphQLErrors: [graphQLError], operation });
+
+        expect(withScopeSpy).toHaveBeenCalledTimes(1);
+        expect(mockScope.setLevel).toHaveBeenCalledWith('error');
+        expect(mockScope.setTag).toHaveBeenCalledWith('type', 'GraphQL Error');
+        expect(mockScope.setTag).toHaveBeenCalledWith(
+          'operation.kind',
+          'query'
+        );
+        expect(mockScope.setContext).toHaveBeenCalledWith(
+          'GraphQL Error',
+          expect.any(Object)
+        );
+        expect(mockScope.setContext).toHaveBeenCalledWith(
+          'Operation',
+          expect.any(Object)
+        );
+        expect(captureExceptionSpy).toHaveBeenCalledTimes(0);
+        expect(captureMessageSpy).toHaveBeenCalledWith(graphQLError.message);
+      });
+
+      it('should ignore JWT expiration and PERMISSION_DENIED errors', () => {
+        const captureExceptionSpy = jest.spyOn(Sentry, 'captureException');
+        const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
+        const graphQLErrors = [
+          {
+            message: 'Invalid Authorization header. JWT has expired.',
+            extensions: {},
+          },
+          {
+            message: '123',
+            extensions: {
+              code: 'PERMISSION_DENIED_ERROR',
+            },
+          },
+        ];
+
+        handleError({ graphQLErrors: graphQLErrors, operation });
+
+        expect(captureExceptionSpy).toHaveBeenCalledTimes(0);
+        expect(captureMessageSpy).toHaveBeenCalledTimes(0);
+      });
+
+      it('should send all errors in development mode', () => {
+        jest.spyOn(Config, 'NODE_ENV', 'get').mockReturnValue('development');
+
+        const graphQLErrors = [
+          {
+            message: 'Invalid Authorization header. JWT has expired.',
+            extensions: {},
+          },
+          {
+            message: 'Permission denied',
+            extensions: {
+              code: 'PERMISSION_DENIED_ERROR',
+            },
+          },
+          {
+            message: 'Any error',
+          },
+        ];
+
+        const consoleErrorSpy = jest
+          .spyOn(console, 'error')
+          .mockImplementation(() => {
+            // pass
+          });
+
+        handleError({ graphQLErrors: graphQLErrors, operation });
+
+        graphQLErrors
+          .map(
+            (graphQLError) =>
+              `[GraphQL error]: Message: ${graphQLError.message}, Location: ${graphQLError.locations}, Path: ${graphQLError.path}`
+          )
+          .forEach((errorMessage) => {
+            expect(consoleErrorSpy).toHaveBeenCalledWith(errorMessage);
+          });
+      });
+
+      it('should capture original error if it exists', () => {
+        const captureExceptionSpy = jest.spyOn(Sentry, 'captureException');
+        const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
+
+        jest
+          .spyOn(Sentry, 'withScope')
+          .mockImplementation((cb) => cb(mockScope));
+
+        const graphQLErrors = [
+          {
+            originalError: new Error('Error test'),
+            message: 'Error test',
+            extensions: {},
+          },
+        ];
+
+        handleError({ graphQLErrors: graphQLErrors, operation });
+
+        expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+        expect(captureMessageSpy).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('network errors', () => {
+      it('should not send network errors', () => {
+        const error = Error('Test');
+        const captureExceptionSpy = jest.spyOn(Sentry, 'captureException');
+        const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
+
+        handleError({ networkError: error, operation });
+
+        expect(captureExceptionSpy).toHaveBeenCalledTimes(0);
+        expect(captureMessageSpy).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+});

--- a/src/api/__tests__/relayList.tests.js
+++ b/src/api/__tests__/relayList.tests.js
@@ -1,0 +1,20 @@
+import RelayList from '../relayList';
+
+describe('RelayList', () => {
+  const items = [{ id: '123', name: 'test' }];
+  const data = {
+    edges: items.map((item) => ({ node: item })),
+  };
+
+  it('should return items', () => {
+    const dataList = RelayList()(data);
+
+    expect(dataList.items).toEqual(items);
+  });
+
+  it('should return an empty list if there is no data', () => {
+    const dataList = RelayList()(null);
+
+    expect(dataList.items).toEqual([]);
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,12 +2,13 @@
 import { ApolloClient, ApolloLink } from '@apollo/client';
 import { InMemoryCache } from '@apollo/client/cache';
 import { setContext } from '@apollo/client/link/context';
-import { onError } from '@apollo/client/link/error';
+import { onError, ErrorHandler } from '@apollo/client/link/error';
 import { createUploadLink } from 'apollo-upload-client';
 import * as Sentry from '@sentry/browser';
 import { OperationDefinitionNode } from 'graphql';
 
 import i18nProvider from '../common/translation/i18nProvider';
+import Config from '../domain/config';
 
 const uploadLink = createUploadLink({
   uri: process.env.REACT_APP_API_URI,
@@ -18,12 +19,17 @@ const uploadLink = createUploadLink({
 
 const stringify = (value: unknown) => JSON.stringify(value, null, 2);
 
-const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
+export const handleError: ErrorHandler = ({
+  graphQLErrors,
+  networkError,
+  operation,
+}) => {
   if (graphQLErrors) {
     graphQLErrors.forEach((graphQLError) => {
       // eslint-disable-next-line max-len
       const errorMessage = `[GraphQL error]: Message: ${graphQLError.message}, Location: ${graphQLError.locations}, Path: ${graphQLError.path}`;
-      if (process.env.NODE_ENV === 'development') {
+
+      if (Config.NODE_ENV === 'development') {
         console.error(errorMessage);
       }
 
@@ -92,7 +98,9 @@ const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
     // eslint-disable-next-line no-console
     console.error(networkError);
   }
-});
+};
+
+const errorLink = onError(handleError);
 
 const authLink = setContext((_, { headers }) => {
   const token = localStorage.getItem('apiToken');

--- a/src/api/generatedTypes/EventGroup.ts
+++ b/src/api/generatedTypes/EventGroup.ts
@@ -75,6 +75,7 @@ export interface EventGroup_eventGroup {
    */
   id: string;
   name: string | null;
+  publishedAt: any | null;
   translations: EventGroup_eventGroup_translations[];
   events: EventGroup_eventGroup_events;
 }

--- a/src/api/generatedTypes/EventsAndEventGroups.ts
+++ b/src/api/generatedTypes/EventsAndEventGroups.ts
@@ -105,6 +105,7 @@ export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroup
    */
   id: string;
   name: string | null;
+  publishedAt: any | null;
   events: EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events;
 }
 

--- a/src/api/generatedTypes/globalTypes.ts
+++ b/src/api/generatedTypes/globalTypes.ts
@@ -128,6 +128,11 @@ export interface MessageTranslationsInput {
   bodyText?: string | null;
 }
 
+export interface PublishEventGroupMutationInput {
+  id: string;
+  clientMutationId?: string | null;
+}
+
 export interface PublishEventMutationInput {
   id: string;
   clientMutationId?: string | null;

--- a/src/api/generatedTypes/publishEventGroup.ts
+++ b/src/api/generatedTypes/publishEventGroup.ts
@@ -1,0 +1,30 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { PublishEventGroupMutationInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: publishEventGroup
+// ====================================================
+
+export interface publishEventGroup_publishEventGroup_eventGroup {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  publishedAt: any | null;
+}
+
+export interface publishEventGroup_publishEventGroup {
+  eventGroup: publishEventGroup_publishEventGroup_eventGroup | null;
+}
+
+export interface publishEventGroup {
+  publishEventGroup: publishEventGroup_publishEventGroup | null;
+}
+
+export interface publishEventGroupVariables {
+  input: PublishEventGroupMutationInput;
+}

--- a/src/domain/children/ChildShow.tsx
+++ b/src/domain/children/ChildShow.tsx
@@ -19,7 +19,7 @@ import {
   Child_child as Child,
   Child_child_occurrences_edges as OccurrenceEdges,
 } from '../../api/generatedTypes/Child';
-import { OccurrenceTimeRangeField } from '../occurrences/fields';
+import OccurrenceTimeRangeField from '../occurrences/fields/OccurrenceTimeRangeField';
 import KukkuuShow from '../application/layout/kukkuuDetailPage/KukkuuShow';
 
 interface RowClickParams<T> {

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -1,0 +1,7 @@
+class Config {
+  static get NODE_ENV() {
+    return process.env.NODE_ENV;
+  }
+}
+
+export default Config;

--- a/src/domain/eventGroups/api/eventGroupsApi.ts
+++ b/src/domain/eventGroups/api/eventGroupsApi.ts
@@ -13,6 +13,7 @@ import {
   addEventGroupMutation,
   updateEventGroupMutation,
   deleteEventGroupMutation,
+  publishEventGroupMutation,
 } from '../mutations/EventGroupMutations';
 
 const EvenList = RelayList<EventNode>();
@@ -75,8 +76,13 @@ async function deleteEventGroup({ id }: MethodHandlerParams) {
   return { data: { id } };
 }
 
-async function publishEventGroup() {
-  return null;
+async function publishEventGroup({ id }: MethodHandlerParams) {
+  const response = await mutationHandler({
+    mutation: publishEventGroupMutation,
+    variables: { input: { id } },
+  });
+
+  return handleApiNode(response.data?.publishEventGroup.eventGroup);
 }
 
 const eventGroupsApi = {

--- a/src/domain/eventGroups/detail/EventGroupsDetail.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetail.tsx
@@ -34,6 +34,8 @@ const EventGroupsDetailActions = ({ data, basePath }: any) => {
   const t = useTranslate();
   const classes = useStyles();
 
+  const isPublished = Boolean(data?.publishedAt);
+
   return (
     <TopToolbar className={classes.toolbar}>
       <CreateButton
@@ -41,7 +43,9 @@ const EventGroupsDetailActions = ({ data, basePath }: any) => {
         label={t('eventGroups.actions.addEvent.do')}
       />
       <EditButton basePath="/event-groups" record={data} />
-      {data && <PublishEventGroupButton basePath={basePath} record={data} />}
+      {data && !isPublished && (
+        <PublishEventGroupButton basePath={basePath} record={data} />
+      )}
     </TopToolbar>
   );
 };

--- a/src/domain/eventGroups/mutations/EventGroupMutations.ts
+++ b/src/domain/eventGroups/mutations/EventGroupMutations.ts
@@ -27,3 +27,14 @@ export const deleteEventGroupMutation = gql`
     }
   }
 `;
+
+export const publishEventGroupMutation = gql`
+  mutation publishEventGroup($input: PublishEventGroupMutationInput!) {
+    publishEventGroup(input: $input) {
+      eventGroup {
+        id
+        publishedAt
+      }
+    }
+  }
+`;

--- a/src/domain/eventGroups/queries/EvenGroupQueries.ts
+++ b/src/domain/eventGroups/queries/EvenGroupQueries.ts
@@ -26,6 +26,7 @@ export const eventGroupQuery = gql`
     eventGroup(id: $id) {
       id
       name
+      publishedAt
       translations {
         languageCode
         name

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -36,7 +36,7 @@ import ViewTitle from '../../../common/components/viewTitle/ViewTitle';
 import LongTextField from '../../../common/components/longTextField/LongTextField';
 import KukkuuPageLayout from '../../application/layout/kukkuuPageLayout/KukkuuPageLayout';
 import KukkuuDetailPage from '../../application/layout/kukkuuDetailPage/KukkuuDetailPage';
-import { OccurrenceTimeRangeField } from '../../occurrences/fields';
+import OccurrenceTimeRangeField from '../../occurrences/fields/OccurrenceTimeRangeField';
 import { AdminEvent } from '../types/EventTypes';
 import { PublishedField } from '../fields';
 import { participantsPerInviteChoices } from '../choices';

--- a/src/domain/eventsAndEventGroups/queries/EventsAndEventGroupsQueries.ts
+++ b/src/domain/eventsAndEventGroups/queries/EventsAndEventGroupsQueries.ts
@@ -31,6 +31,7 @@ export const eventsAndEventGroupsQuery = gql`
           ... on EventGroupNode {
             id
             name
+            publishedAt
             events {
               edges {
                 node {

--- a/src/domain/occurrences/Guardian.ts
+++ b/src/domain/occurrences/Guardian.ts
@@ -1,0 +1,25 @@
+import i18nProvider from '../../common/translation/i18nProvider';
+
+type GuardianType = {
+  firstName: string | null;
+  lastName: string | null;
+  language: string | null;
+};
+
+class Guardian {
+  guardian: GuardianType;
+
+  constructor(guardian: GuardianType) {
+    this.guardian = guardian;
+  }
+
+  get fullName() {
+    return `${this.guardian.firstName} ${this.guardian.lastName}`.trim();
+  }
+
+  get language() {
+    return i18nProvider.translate(`languages.${this.guardian.language}`);
+  }
+}
+
+export default Guardian;

--- a/src/domain/occurrences/Occurrence.ts
+++ b/src/domain/occurrences/Occurrence.ts
@@ -4,7 +4,13 @@ import i18nProvider from '../../common/translation/i18nProvider';
 type OccurrenceType = {
   time: string;
   event: {
+    id: string;
+    name: string | null;
     duration: number | null;
+    eventGroup: {
+      id: string;
+      name: string | null;
+    } | null;
   };
 };
 
@@ -50,6 +56,34 @@ class Occurrence {
     );
 
     return `${translatedResourceName} ${this.occurrenceDateAndDuration}`;
+  }
+
+  get breadcrumbs() {
+    const crumbs = [
+      {
+        label: i18nProvider.translate('events.list.title'),
+        link: '/events-and-event-groups',
+      },
+    ];
+
+    const eventGroup = this.occurrence?.event?.eventGroup;
+    const event = this.occurrence?.event;
+
+    if (eventGroup) {
+      const eventGroupName = eventGroup.name ?? '';
+
+      crumbs.push({
+        label: eventGroupName,
+        link: `/event-groups/${eventGroup.id}/show`,
+      });
+    }
+
+    crumbs.push({
+      label: event?.name || '',
+      link: `/events/${event?.id}/show`,
+    });
+
+    return crumbs;
   }
 }
 

--- a/src/domain/occurrences/OccurrenceArraySelect.tsx
+++ b/src/domain/occurrences/OccurrenceArraySelect.tsx
@@ -22,7 +22,9 @@ const AllChoice = ({
   });
 };
 
-function getFilters(eventId?: string): Record<string, string> | undefined {
+export function getFilters(
+  eventId?: string
+): Record<string, string> | undefined {
   if (!eventId) {
     return;
   }
@@ -31,6 +33,29 @@ function getFilters(eventId?: string): Record<string, string> | undefined {
     eventId,
   };
 }
+
+export const getChoices = (records: Occurrence[]) => {
+  return records.map(({ id, time }) => ({
+    id,
+    name: toShortDateTimeString(new Date(time)),
+  }));
+};
+
+export const getValues = (previousValues: string[], nextValues: string[]) => {
+  const wasAllSelected = previousValues.includes('all');
+  const willHaveOtherValueThanAll = nextValues.length > 0;
+  const willHaveNoValue = nextValues.length === 0;
+  const allWillBeAdded =
+    !previousValues.includes('all') && nextValues.includes('all');
+
+  if (wasAllSelected && willHaveOtherValueThanAll) {
+    return nextValues.filter((value: string) => value !== 'all');
+  } else if (willHaveNoValue || allWillBeAdded) {
+    return ['all'];
+  } else {
+    return nextValues;
+  }
+};
 
 type ReferenceArrayInputProps = Parameters<typeof ReferenceArrayInput>[0];
 type Props = Omit<ReferenceArrayInputProps, 'children' | 'reference'> & {
@@ -57,29 +82,9 @@ const OccurrenceArraySelect = ({ eventId, allText, ...rest }: Props) => {
     // The value is actually an array because we are using a
     // multi select
     const nextValues = (e.target.value as unknown) as string[];
-    const wasAllSelected = previousValues.includes('all');
-    const willHaveOtherValueThanAll = nextValues.length > 0;
-    const willHaveNoValue = nextValues.length === 0;
-    const allWillBeAdded =
-      !previousValues.includes('all') && nextValues.includes('all');
+    const values = getValues(previousValues, nextValues);
 
-    if (wasAllSelected && willHaveOtherValueThanAll) {
-      form.change(
-        field.input.name,
-        nextValues.filter((value: string) => value !== 'all')
-      );
-    } else if (willHaveNoValue || allWillBeAdded) {
-      form.change(field.input.name, ['all']);
-    } else {
-      form.change(field.input.name, nextValues);
-    }
-  };
-
-  const getChoices = (records: Occurrence[]) => {
-    return records.map(({ id, time }) => ({
-      id,
-      name: toShortDateTimeString(new Date(time)),
-    }));
+    form.change(field.input.name, values);
   };
 
   return (

--- a/src/domain/occurrences/OccurrenceShow.tsx
+++ b/src/domain/occurrences/OccurrenceShow.tsx
@@ -11,81 +11,21 @@ import {
   EmailField,
   ArrayField,
   FunctionField,
-  useDataProvider,
   useGetOne,
   Record,
 } from 'react-admin';
-import PropTypes from 'prop-types';
-import Select from '@material-ui/core/Select';
-import MenuItem from '@material-ui/core/MenuItem';
-import FormControl from '@material-ui/core/FormControl';
 import makeStyles from '@material-ui/styles/makeStyles';
 
 import {
   Occurrences_occurrences_edges_node_enrolments_edges as EnrolmentEdge,
-  Occurrences_occurrences_edges_node_enrolments_edges_node as Enrolment,
   Occurrences_occurrences_edges_node_enrolments_edges_node_child_guardians_edges_node as Guardian,
   Occurrences_occurrences_edges_node as OccurrenceType,
 } from '../../api/generatedTypes/Occurrences';
 import KukkuuPageLayout from '../application/layout/kukkuuPageLayout/KukkuuPageLayout';
 import KukkuuDetailPage from '../application/layout/kukkuuDetailPage/KukkuuDetailPage';
-import { OccurrenceTimeRangeField } from './fields';
+import OccurrenceTimeRangeField from './fields/OccurrenceTimeRangeField';
+import OccurrenceAttendedField from './fields/OccurrenceAttendedField';
 import Occurrence from './Occurrence';
-
-type AttendedFieldProps = {
-  record?: EnrolmentEdge;
-};
-
-const AttendedField = ({ record }: AttendedFieldProps) => {
-  const enrolment = record?.node as Enrolment; // enrolment should be never undefined or null here
-  const [attended, setAttended] = React.useState(
-    JSON.stringify(enrolment.attended)
-  );
-  const dataProvider = useDataProvider();
-  const translate = useTranslate();
-  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    const value = event.target.value as string;
-    dataProvider.setEnrolmentAttendance(enrolment.id, JSON.parse(value));
-    setAttended(value);
-  };
-  return (
-    <FormControl fullWidth>
-      <Select
-        style={{ fontSize: '0.875rem' }}
-        disableUnderline
-        value={attended}
-        onChange={handleChange}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <MenuItem value="null">
-          <em>
-            {translate(
-              'occurrences.fields.enrolments.fields.attended.choices.null'
-            )}
-          </em>
-        </MenuItem>
-        <MenuItem value="true">
-          {translate(
-            'occurrences.fields.enrolments.fields.attended.choices.true'
-          )}
-        </MenuItem>
-        <MenuItem value="false">
-          {translate(
-            'occurrences.fields.enrolments.fields.attended.choices.false'
-          )}
-        </MenuItem>
-      </Select>
-    </FormControl>
-  );
-};
-
-AttendedField.propTypes = {
-  record: PropTypes.object,
-};
-
-AttendedField.defaultProps = {
-  label: 'enrolments.fields.attended.label',
-};
 
 const useDataGridTitleStyles = makeStyles({
   fakeValue: {
@@ -254,7 +194,7 @@ const OccurrenceShow = (props: any) => {
               render={(record: EnrolmentEdge) => getGuardianLanguage(record)}
               label="events.fields.language.label"
             />
-            <AttendedField />
+            <OccurrenceAttendedField />
           </Datagrid>
         </ArrayField>
       </SimpleShowLayout>

--- a/src/domain/occurrences/__tests__/Occurrence.test.js
+++ b/src/domain/occurrences/__tests__/Occurrence.test.js
@@ -1,0 +1,53 @@
+import Occurrence from '../Occurrence';
+
+describe('Occurrence helper class', () => {
+  const occurrence = new Occurrence({
+    time: '2020-10-10',
+    event: {
+      duration: 30,
+    },
+  });
+
+  describe('getters', () => {
+    it('time', () => {
+      expect(occurrence.time).toMatchInlineSnapshot(`"10.10.2020 klo 03.00"`);
+    });
+
+    it('startTime', () => {
+      expect(occurrence.startTime).toMatchInlineSnapshot(`"03.00"`);
+    });
+
+    it('endTime', () => {
+      expect(occurrence.endTime).toMatchInlineSnapshot(`"03.30"`);
+    });
+
+    it('duration', () => {
+      expect(occurrence.duration).toMatchInlineSnapshot(`"03.00 - 03.30"`);
+    });
+
+    it('duration without occurrence.duration', () => {
+      const occurrenceWithoutDuration = new Occurrence({
+        time: '2020-10-10',
+        event: {
+          duration: null,
+        },
+      });
+
+      expect(occurrenceWithoutDuration.duration).toMatchInlineSnapshot(
+        `"03.00 - null"`
+      );
+    });
+
+    it('occurrenceDateAndDuration', () => {
+      expect(occurrence.occurrenceDateAndDuration).toMatchInlineSnapshot(
+        `"10.10.2020 klo 03.00 - 03.30"`
+      );
+    });
+
+    it('title', () => {
+      expect(occurrence.title).toMatchInlineSnapshot(
+        `"Esiintymä 10.10.2020 klo 03.00 - 03.30"`
+      );
+    });
+  });
+});

--- a/src/domain/occurrences/__tests__/Occurrence.test.js
+++ b/src/domain/occurrences/__tests__/Occurrence.test.js
@@ -1,12 +1,19 @@
 import Occurrence from '../Occurrence';
 
 describe('Occurrence helper class', () => {
-  const occurrence = new Occurrence({
+  const occurrenceData = {
     time: '2020-10-10',
     event: {
+      id: '123',
+      name: 'Event name',
       duration: 30,
+      eventGroup: {
+        id: '123',
+        name: 'Event Group Name',
+      },
     },
-  });
+  };
+  const occurrence = new Occurrence(occurrenceData);
 
   describe('getters', () => {
     it('time', () => {
@@ -48,6 +55,48 @@ describe('Occurrence helper class', () => {
       expect(occurrence.title).toMatchInlineSnapshot(
         `"Esiintymä 10.10.2020 klo 03.00 - 03.30"`
       );
+    });
+
+    it('breadcrumbs when the event is within an event group', () => {
+      expect(occurrence.breadcrumbs).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "label": "Tapahtumat",
+            "link": "/events-and-event-groups",
+          },
+          Object {
+            "label": "Event Group Name",
+            "link": "/event-groups/123/show",
+          },
+          Object {
+            "label": "Event name",
+            "link": "/events/123/show",
+          },
+        ]
+      `);
+    });
+
+    it('breadcrumbs when the event is not within an event group', () => {
+      const occurrenceWithoutEventGroup = new Occurrence({
+        ...occurrenceData,
+        event: {
+          ...occurrenceData.event,
+          eventGroup: undefined,
+        },
+      });
+
+      expect(occurrenceWithoutEventGroup.breadcrumbs).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "label": "Tapahtumat",
+            "link": "/events-and-event-groups",
+          },
+          Object {
+            "label": "Event name",
+            "link": "/events/123/show",
+          },
+        ]
+      `);
     });
   });
 });

--- a/src/domain/occurrences/__tests__/OccurrenceArraySelect.test.js
+++ b/src/domain/occurrences/__tests__/OccurrenceArraySelect.test.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestContext, SimpleForm } from 'react-admin';
+
+import OccurrenceArraySelect, {
+  getChoices,
+  getFilters,
+  getValues,
+} from '../OccurrenceArraySelect';
+
+describe('<OccurrenceArraySelect />', () => {
+  it('should render without errors', () => {
+    jest.spyOn(global.console, 'error').mockImplementationOnce(() => null);
+
+    expect(
+      render(
+        <TestContext
+          initialState={{ admin: { resources: { occurrences: { data: {} } } } }}
+        >
+          <SimpleForm>
+            <OccurrenceArraySelect eventId="1" source="event" />
+          </SimpleForm>
+        </TestContext>
+      )
+    ).toMatchSnapshot();
+  });
+});
+
+describe('OccurrenceArraySelect helpers', () => {
+  describe('getFilters', () => {
+    it('should return undefined if there is no event id', () => {
+      expect(getFilters()).toBeUndefined();
+    });
+
+    it('otherwise it should return filters', () => {
+      expect(getFilters('123')).toEqual({
+        eventId: '123',
+      });
+    });
+  });
+
+  describe('getChoices', () => {
+    it('should make choices out of occurrences', () => {
+      const occurrences = [
+        {
+          id: '123',
+          time: '2020-10-7',
+        },
+        {
+          id: '12',
+          time: '2020-11-7',
+        },
+      ];
+      const choices = getChoices(occurrences);
+
+      expect(choices.length).toEqual(occurrences.length);
+      expect(choices[0]).toMatchInlineSnapshot(`
+        Object {
+          "id": "123",
+          "name": "7.10.2020, 00.00",
+        }
+      `);
+    });
+  });
+
+  describe('getValues', () => {
+    it('should remove all from selected values if some other option is selected', () => {
+      expect(getValues(['all'], ['other options']).includes('all')).toBe(false);
+    });
+
+    it('should only return all if all is selected', () => {
+      expect(getValues(['value 1', 'value 1'], ['all'])).toEqual(['all']);
+    });
+
+    it('should return all if nothing is selected', () => {
+      expect(getValues(['value 1', 'value 1'], [])).toEqual(['all']);
+    });
+
+    it('otherwise it should return next values', () => {
+      const nextValues = ['value 1', 'value 2'];
+
+      expect(getValues(['value 1'], nextValues)).toEqual(nextValues);
+    });
+  });
+});

--- a/src/domain/occurrences/__tests__/OccurrenceShow.test.jsx
+++ b/src/domain/occurrences/__tests__/OccurrenceShow.test.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { TestContext } from 'react-admin';
+import { render } from '@testing-library/react';
+
+import OccurrenceShow, {
+  withGuardian,
+  getGuardianFullName,
+  getGuardianLanguage,
+  getBreadCrumbs,
+  getTitle,
+  getChildFullName,
+  withEnrolment,
+} from '../OccurrenceShow';
+import Occurrence from '../Occurrence';
+
+describe('OccurrenceShow utils', () => {
+  const guardian = {
+    firstName: 'Leo',
+    lastName: 'Garri',
+    language: 'FI',
+  };
+  const enrollment = {
+    node: {
+      child: {
+        guardians: {
+          edges: [
+            {
+              node: guardian,
+            },
+          ],
+        },
+      },
+    },
+  };
+  const occurrence = {
+    time: '2020-10-7',
+    event: {
+      duration: 30,
+    },
+  };
+
+  describe('getTitle', () => {
+    it('should return correct title', () => {
+      expect(getTitle(occurrence)).toMatchInlineSnapshot(
+        `"Esiintymä 7.10.2020 klo 00.00 - 00.30"`
+      );
+    });
+  });
+
+  describe('getBreadcrumbs', () => {
+    it('should call Occurrence.breadcrumbs', () => {
+      const occurrenceBreadcrumbsSpy = jest.spyOn(
+        Occurrence.prototype,
+        'breadcrumbs',
+        'get'
+      );
+
+      getBreadCrumbs(occurrence);
+
+      expect(occurrenceBreadcrumbsSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getChildFullName', () => {
+    it('should return correct title', () => {
+      expect(getChildFullName(guardian)).toMatchInlineSnapshot(
+        `"undefined undefined"`
+      );
+    });
+  });
+
+  describe('withEnrolment', () => {
+    it('should call otherwise if guardian does not exist', () => {
+      const otherwise = jest.fn();
+
+      withEnrolment(jest.fn(), otherwise)(null);
+
+      expect(otherwise).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call hasRecord function with a record if one exists', () => {
+      const renderFunction = jest.fn();
+
+      withEnrolment(renderFunction, jest.fn())(enrollment);
+
+      expect(renderFunction).toHaveBeenCalledTimes(1);
+      expect(renderFunction).toHaveBeenCalledWith(enrollment);
+    });
+  });
+
+  describe('withGuardian', () => {
+    it('should call otherwise if guardian does not exist', () => {
+      const otherwise = jest.fn();
+
+      withGuardian(jest.fn(), otherwise)({ node: null });
+
+      expect(otherwise).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call hasGuardian function with a guardian if one exists', () => {
+      const renderFunction = jest.fn();
+
+      withGuardian(renderFunction, jest.fn())(enrollment);
+
+      expect(renderFunction).toHaveBeenCalledTimes(1);
+      expect(renderFunction).toHaveBeenCalledWith(guardian);
+    });
+  });
+
+  describe('getGuardianFullName', () => {
+    it('should return the full name of the guardian', () => {
+      expect(getGuardianFullName(guardian)).toMatchInlineSnapshot(
+        `"Leo Garri"`
+      );
+    });
+  });
+
+  describe('getGuardianLanguage', () => {
+    it('should return the translated language of the guardian', () => {
+      expect(getGuardianLanguage(guardian)).toMatchInlineSnapshot(`"suomi"`);
+    });
+  });
+});

--- a/src/domain/occurrences/__tests__/__snapshots__/OccurrenceArraySelect.test.js.snap
+++ b/src/domain/occurrences/__tests__/__snapshots__/OccurrenceArraySelect.test.js.snap
@@ -1,0 +1,214 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<OccurrenceArraySelect /> should render without errors 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <form
+        class="simple-form"
+      >
+        <div
+          class="MuiCardContent-root RaCardContentInner-root-1"
+        >
+          <div
+            class="ra-input ra-input-event"
+          >
+            <div
+              class="MuiFormControl-root RaFormInput-input-2 MuiFormControl-marginDense"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root RaLabeled-label-3 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-marginDense"
+                data-shrink="true"
+              >
+                <span>
+                  resources.occurrences.fields.event
+                </span>
+              </label>
+              <div
+                class="RaLabeled-value-4"
+              >
+                <div
+                  class="MuiLinearProgress-root MuiLinearProgress-colorPrimary RaLinearProgress-root-5 MuiLinearProgress-indeterminate"
+                  resource="occurrences"
+                  role="progressbar"
+                >
+                  <div
+                    class="MuiLinearProgress-bar MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Indeterminate"
+                  />
+                  <div
+                    class="MuiLinearProgress-bar MuiLinearProgress-bar2Indeterminate MuiLinearProgress-barColorPrimary"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiToolbar-root MuiToolbar-regular RaToolbar-toolbar-6 RaToolbar-mobileToolbar-8 MuiToolbar-gutters"
+          role="toolbar"
+        >
+          <div
+            class="RaToolbar-defaultToolbar-9"
+          >
+            <button
+              aria-label="ra.action.save"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained RaSaveButton-button-11 MuiButton-containedPrimary Mui-disabled Mui-disabled"
+              disabled=""
+              tabindex="-1"
+              type="submit"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root RaSaveButton-leftIcon-12 RaSaveButton-icon-13"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"
+                  />
+                </svg>
+                ra.action.save
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="RaToolbar-spacer-10"
+        />
+      </form>
+    </div>
+  </body>,
+  "container": <div>
+    <form
+      class="simple-form"
+    >
+      <div
+        class="MuiCardContent-root RaCardContentInner-root-1"
+      >
+        <div
+          class="ra-input ra-input-event"
+        >
+          <div
+            class="MuiFormControl-root RaFormInput-input-2 MuiFormControl-marginDense"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root RaLabeled-label-3 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-marginDense"
+              data-shrink="true"
+            >
+              <span>
+                resources.occurrences.fields.event
+              </span>
+            </label>
+            <div
+              class="RaLabeled-value-4"
+            >
+              <div
+                class="MuiLinearProgress-root MuiLinearProgress-colorPrimary RaLinearProgress-root-5 MuiLinearProgress-indeterminate"
+                resource="occurrences"
+                role="progressbar"
+              >
+                <div
+                  class="MuiLinearProgress-bar MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Indeterminate"
+                />
+                <div
+                  class="MuiLinearProgress-bar MuiLinearProgress-bar2Indeterminate MuiLinearProgress-barColorPrimary"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiToolbar-root MuiToolbar-regular RaToolbar-toolbar-6 RaToolbar-mobileToolbar-8 MuiToolbar-gutters"
+        role="toolbar"
+      >
+        <div
+          class="RaToolbar-defaultToolbar-9"
+        >
+          <button
+            aria-label="ra.action.save"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained RaSaveButton-button-11 MuiButton-containedPrimary Mui-disabled Mui-disabled"
+            disabled=""
+            tabindex="-1"
+            type="submit"
+          >
+            <span
+              class="MuiButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root RaSaveButton-leftIcon-12 RaSaveButton-icon-13"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"
+                />
+              </svg>
+              ra.action.save
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="RaToolbar-spacer-10"
+      />
+    </form>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/domain/occurrences/__tests__/inputs.test.js
+++ b/src/domain/occurrences/__tests__/inputs.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestContext, SimpleForm } from 'react-admin';
+
+import i18nProvider from '../../../common/translation/i18nProvider';
+import { OccurrenceCapacityOverrideInput } from '../inputs';
+
+describe('inputs', () => {
+  describe('<OccurrenceCapacityOverrideInput />', () => {
+    const defaultProps = {
+      record: {
+        event: {
+          capacityPerOccurrence: 2,
+        },
+      },
+      id: 'test-1',
+    };
+    const getWrapper = () =>
+      render(
+        <TestContext i18nProvider={i18nProvider}>
+          <SimpleForm>
+            <OccurrenceCapacityOverrideInput {...defaultProps} />
+          </SimpleForm>
+        </TestContext>
+      );
+
+    it('should render input', () => {
+      const { getByLabelText } = getWrapper();
+
+      expect(
+        getByLabelText('occurrences.fields.capacityOverride.label')
+      ).toBeTruthy();
+    });
+
+    it('should render description', () => {
+      const { getByText } = getWrapper();
+
+      expect(
+        getByText('occurrences.fields.capacityOverride.helperText')
+      ).toBeTruthy();
+    });
+  });
+});

--- a/src/domain/occurrences/fields/OccurrenceAttendedField.tsx
+++ b/src/domain/occurrences/fields/OccurrenceAttendedField.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useTranslate, useDataProvider } from 'react-admin';
+import PropTypes from 'prop-types';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+
+import {
+  Occurrences_occurrences_edges_node_enrolments_edges as EnrolmentEdge,
+  Occurrences_occurrences_edges_node_enrolments_edges_node as Enrolment,
+} from '../../../api/generatedTypes/Occurrences';
+
+type Props = {
+  record?: EnrolmentEdge;
+};
+
+const OccurrenceAttendedField = ({ record }: Props) => {
+  const enrolment = record?.node as Enrolment; // enrolment should be never undefined or null here
+  const [attended, setAttended] = React.useState(
+    JSON.stringify(enrolment.attended)
+  );
+  const dataProvider = useDataProvider();
+  const translate = useTranslate();
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    const value = event.target.value as string;
+    dataProvider.setEnrolmentAttendance(enrolment.id, JSON.parse(value));
+    setAttended(value);
+  };
+  return (
+    <FormControl fullWidth>
+      <Select
+        style={{ fontSize: '0.875rem' }}
+        disableUnderline
+        value={attended}
+        onChange={handleChange}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <MenuItem value="null">
+          <em>
+            {translate(
+              'occurrences.fields.enrolments.fields.attended.choices.null'
+            )}
+          </em>
+        </MenuItem>
+        <MenuItem value="true">
+          {translate(
+            'occurrences.fields.enrolments.fields.attended.choices.true'
+          )}
+        </MenuItem>
+        <MenuItem value="false">
+          {translate(
+            'occurrences.fields.enrolments.fields.attended.choices.false'
+          )}
+        </MenuItem>
+      </Select>
+    </FormControl>
+  );
+};
+
+OccurrenceAttendedField.propTypes = {
+  record: PropTypes.object,
+};
+
+OccurrenceAttendedField.defaultProps = {
+  label: 'enrolments.fields.attended.label',
+};
+
+export default OccurrenceAttendedField;

--- a/src/domain/occurrences/fields/OccurrenceTimeRangeField.tsx
+++ b/src/domain/occurrences/fields/OccurrenceTimeRangeField.tsx
@@ -2,10 +2,10 @@ import get from 'lodash/get';
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-import { Occurrences_occurrences_edges_node as OccurrenceType } from '../../api/generatedTypes/Occurrences';
-import Occurrence from './Occurrence';
+import { Occurrences_occurrences_edges_node as OccurrenceType } from '../../../api/generatedTypes/Occurrences';
+import Occurrence from '../Occurrence';
 
-export const OccurrenceTimeRangeField = ({
+const OccurrenceTimeRangeField = ({
   record,
   occurrenceSource,
 }: {
@@ -32,3 +32,5 @@ OccurrenceTimeRangeField.defaultProps = {
   addLabel: true,
   label: 'occurrences.fields.time.fields.time.label',
 };
+
+export default OccurrenceTimeRangeField;


### PR DESCRIPTION
## Description

While waiting for the API endpoint to be released, I improved the test coverage of this application by adding browser tests to the event feature and by adding unit tests for some occurrence feature functions.

The main purpose of this PR is to implement the publish button functionality for event groups. After this PR the button should work.

## Context

[KK-633](https://helsinkisolutionoffice.atlassian.net/browse/KK-633)

## How Has This Been Tested?

I've added a browser test that checks that event groups can be published.

## Manual Testing Instructions for Reviewers

As a logged in user

1. Access even group list
1. Add event group
1. Select created group
1. Publish it
1. Expect it to be show as published in the events and event groups list
1. Select the created group
1. Expect publish button to be hidden