### PR TITLE
Chore | Fix browser test

### DIFF
--- a/browser-tests/eventFeature.ts
+++ b/browser-tests/eventFeature.ts
@@ -1,5 +1,3 @@
-import { Selector } from 'testcafe';
-
 import { routes } from './pages/routes';
 import { login } from './utils/login';
 import { navigation } from './pages/navigation';

--- a/browser-tests/eventFeature.ts
+++ b/browser-tests/eventFeature.ts
@@ -1,3 +1,5 @@
+import { Selector } from 'testcafe';
+
 import { routes } from './pages/routes';
 import { login } from './utils/login';
 import { navigation } from './pages/navigation';
@@ -48,6 +50,9 @@ test('As an admin I want to be able to create, update and delete events', async 
   // Assert that we have been redirected to the events details
   await t.expect(eventsDetailPage.title(createEvent.name).exists).ok();
 
+  // Wait some time for data to be fetched, so that the edit button
+  // points to the correct resource.
+  await t.wait(1000);
   // Go to edit view
   await t.click(eventsDetailPage.editButton);
 
@@ -64,6 +69,7 @@ test('As an admin I want to be able to create, update and delete events', async 
 
   // Assert that we have been redirected to the events list
   await t.expect(eventsListPage.title.exists).ok();
+
   // And that the event no longer exists
   await t
     .expect(eventsListPage.eventOrEventGroupByName(updateEvent.name).exists)

--- a/browser-tests/eventGroupsFeature.ts
+++ b/browser-tests/eventGroupsFeature.ts
@@ -178,6 +178,8 @@ test('As an admin I want to be able to add events to an event group', async (t) 
   await t.click(eventGroupsDetailPage.getEvent(event.name));
 
   await deleteEvent(t);
+
+  await t.expect(eventGroupsDetailPage.getEvent(event.name).exists).notOk();
 });
 
 test('As an admin I want to be able to publish an event group', async (t) => {

--- a/browser-tests/messageFeature.ts
+++ b/browser-tests/messageFeature.ts
@@ -36,7 +36,7 @@ fixture`Messages feature`
     delete t.ctx.message;
   });
 
-test('As an admin I want see a list of messages', async (t) => {
+test('As an admin I want to see a list of messages', async (t) => {
   // The list displays the expected fields
   await t
     .expect(messagesListPage.listHeader.filter(includesHeaders).exists)

--- a/browser-tests/pages/events.ts
+++ b/browser-tests/pages/events.ts
@@ -22,7 +22,7 @@ export const eventsDetailPage = {
   editButton: screen.getByRole('button', {
     name: 'Muokkaa',
   }),
-  title: (name: string) => Selector('h1'),
+  title: (name: string) => Selector('h1').withExactText(name),
 };
 
 const eventForm = {
@@ -69,4 +69,11 @@ export async function deleteEvent(t: TestController) {
 
   // Delete the event
   await t.click(eventsEditPage.deleteButton);
+
+  // Click anywhere on the page to cancel the undo waiting time for
+  // completing the action
+  await t.click(eventsListPage.title);
+
+  // Wait for undo timer to be canceled
+  await t.wait(100);
 }


### PR DESCRIPTION
## Description

Browser tests were failing in the CI. I think this was due to two reasons. First, load times are a tad bit longer in the CI environment. This caused the `editButton` in the event details view to be clicked before the event had loaded. The edit button uses the event record for obtaining the `id` of the event. Without the record, it would redirect to an event that did not exist, leading to a failure in the test.

Further, the deletion procedure would fail in the CI. The event model uses the "undo" pattern for deleting events. With react-admin, this works like so:
* user clicks delete
* the model is deleted from the state of the application, but no delete request is sent
* the user has 4s to click "undo" in which case the delete request would be stopped from executing
* unless the user interacts with the page, or lets four seconds pass, the model won't be deleted

In essence, the event was not really deleted because the test did not contain any other interactions after the deletion procedure. The UI looked as if the event had been deleted, but the actual delete request had not yet been fired. With local tests, the four seconds would often end up passing, making the behaviour hard to spot.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

https://github.com/City-of-Helsinki/kukkuu-admin/actions/runs/395737380

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

I've ran the browser tests against this branch and they seem to be working now: https://github.com/City-of-Helsinki/kukkuu-admin/actions/runs/400519017
