### PR TITLE
KK-615 | Hide event publish button under event group

### DIFF
--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -130,12 +130,17 @@ const EventShowActions = ({
 }: {
   basePath?: string;
   data?: AdminEvent;
-}) => (
-  <TopToolbar>
-    <EditButton basePath={basePath} record={data} />
-    <PublishButton record={data} />
-  </TopToolbar>
-);
+}) => {
+  const hasData = Boolean(data);
+  const hasEventGroup = Boolean(data?.eventGroup);
+
+  return (
+    <TopToolbar>
+      <EditButton basePath={basePath} record={data} />
+      {hasData && !hasEventGroup && <PublishButton record={data} />}
+    </TopToolbar>
+  );
+};
 
 const EventShow = (props: ResourceComponentPropsWithId) => {
   const locale = useLocale();

--- a/src/domain/events/types/EventTypes.ts
+++ b/src/domain/events/types/EventTypes.ts
@@ -1,5 +1,6 @@
 import { AdminUITranslation } from '../../../api/types';
 import { Events_events_edges_node_translations as ApiEventTranslation } from '../../../api/generatedTypes/Events';
+import { Event_event_eventGroup as EventGroup } from '../../../api/generatedTypes/Event';
 import { EventParticipantsPerInvite } from '../../../api/generatedTypes/globalTypes';
 
 export interface AdminEvent {
@@ -9,4 +10,5 @@ export interface AdminEvent {
   duration: number;
   publishedAt?: string;
   translations: AdminUITranslation<Omit<ApiEventTranslation, 'languageCode'>>;
+  eventGroup?: EventGroup;
 }


### PR DESCRIPTION
## Description

The publish button for events under an event group should be hidden, because they should be published by using the event group.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-615](https://helsinkisolutionoffice.atlassian.net/browse/KK-615)

## How Has This Been Tested?

I've tested this manually.

## Manual Testing Instructions for Reviewers

As a logged in user

1. Go to event list
1. Select event group
1. Select event
1. Expect to not see a publish button
1. Go to event list
1. Select a "loose" event
1. Expect to see a publish button