### PR TITLE
KK-673 | Add a button for setting an event as ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,9 @@ Travis is configured to run a cron job daily. The browser tests are hooked to th
 ## Debugging
 
 See instructions in the sister project: https://github.com/City-of-Helsinki/kukkuu-ui/
+
+## Feature Flags
+
+`REACT_APP_ENABLE_EVENT_READY_TICK`
+
+Can be used to toggle a toggle used for marking an event as ready on or off. At the time when this feature was first implemented, the API was not yet finalized so this feature could not be put live. In order to avoid leaving the code in an open branch indefinitely, a feature flag was used to toggle off the functionality until it can be integrated with the API.

--- a/src/api/dataProvider.ts
+++ b/src/api/dataProvider.ts
@@ -18,6 +18,7 @@ import {
   updateEvent,
   publishEvent,
   deleteEvent,
+  setReady,
 } from '../domain/events/api/EventApi';
 import {
   addOccurrence,
@@ -52,6 +53,7 @@ const METHOD_HANDLERS: MethodHandlers = {
     UPDATE: updateEvent,
     DELETE: deleteEvent,
     PUBLISH: publishEvent,
+    SET_READY: setReady,
   },
   occurrences: {
     LIST: getOccurrences,
@@ -138,6 +140,8 @@ const dataProvider = {
     runHandler('SEND', resource, params),
   getMyAdminProfile,
   setEnrolmentAttendance,
+  setReady: async (resource: Resource, params: Params) =>
+    runHandler('SET_READY', resource, params),
 };
 
 export default dataProvider;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -27,7 +27,8 @@ export type Method =
   | 'DELETE'
   | 'DELETE_MANY'
   | 'PUBLISH'
-  | 'SEND';
+  | 'SEND'
+  | 'SET_READY';
 
 export type Record = { [index: string]: any; id: string };
 

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -138,6 +138,9 @@
       },
       "totalCapacity": {
         "label": "Total capacity"
+      },
+      "ready": {
+        "label": "Ready to be published"
       }
     },
     "list": {

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -138,6 +138,9 @@
       },
       "totalCapacity": {
         "label": "Kokonaiskapasiteetti"
+      },
+      "ready": {
+        "label": "Valmis julkaistavaksi"
       }
     },
     "list": {

--- a/src/domain/__tests__/config.test.js
+++ b/src/domain/__tests__/config.test.js
@@ -1,0 +1,33 @@
+import Config from '../config';
+
+describe('Config', () => {
+  let env = {};
+
+  beforeEach(() => {
+    env = process.env;
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it('provides node env', () => {
+    process.env.NODE_ENV = 'production';
+
+    expect(Config.NODE_ENV).toEqual('production');
+
+    process.env.NODE_ENV = 'development';
+
+    expect(Config.NODE_ENV).toEqual('development');
+  });
+
+  it('provides enableEventReadyTick', () => {
+    delete process.env.REACT_APP_ENABLE_EVENT_READY_TICK;
+
+    expect(Config.enableEventReadyTick).toBeFalsy();
+
+    process.env.REACT_APP_ENABLE_EVENT_READY_TICK = 'true';
+
+    expect(Config.enableEventReadyTick).toBeTruthy();
+  });
+});

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -2,6 +2,10 @@ class Config {
   static get NODE_ENV() {
     return process.env.NODE_ENV;
   }
+
+  static get enableEventReadyTick() {
+    return process.env.REACT_APP_ENABLE_EVENT_READY_TICK;
+  }
 }
 
 export default Config;

--- a/src/domain/events/api/EventApi.ts
+++ b/src/domain/events/api/EventApi.ts
@@ -89,6 +89,10 @@ const deleteEvent: MethodHandler = async (params: MethodHandlerParams) => {
   return { data: { id: params.id } };
 };
 
+const setReady: MethodHandler = async (params: MethodHandlerParams) => {
+  return Promise.resolve(null);
+};
+
 export {
   getEvents,
   getEvent,
@@ -96,4 +100,5 @@ export {
   updateEvent,
   publishEvent,
   deleteEvent,
+  setReady,
 };

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -27,6 +27,9 @@ import { withStyles, WithStyles, createStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 import AddIcon from '@material-ui/icons/Add';
 import DoneOutlineIcon from '@material-ui/icons/DoneOutline';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import { makeStyles } from '@material-ui/core';
 import * as Sentry from '@sentry/browser';
 
 import { Language } from '../../../api/generatedTypes/globalTypes';
@@ -37,6 +40,7 @@ import LongTextField from '../../../common/components/longTextField/LongTextFiel
 import KukkuuPageLayout from '../../application/layout/kukkuuPageLayout/KukkuuPageLayout';
 import KukkuuDetailPage from '../../application/layout/kukkuuDetailPage/KukkuuDetailPage';
 import OccurrenceTimeRangeField from '../../occurrences/fields/OccurrenceTimeRangeField';
+import config from '../../config';
 import { AdminEvent } from '../types/EventTypes';
 import { PublishedField } from '../fields';
 import { participantsPerInviteChoices } from '../choices';
@@ -124,6 +128,45 @@ const PublishButton = ({ record }: { record?: AdminEvent }) => {
   );
 };
 
+type IsReadyToggleProps = {
+  record: AdminEvent;
+  className?: string;
+};
+
+const IsReadyToggle = ({ record, className }: IsReadyToggleProps) => {
+  const [setReady] = useMutation({
+    type: 'setReady',
+    resource: 'events',
+    payload: { id: record.id },
+  });
+
+  const handleClick = () => {
+    setReady();
+  };
+
+  return (
+    <FormControlLabel
+      className={className}
+      control={
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        <Switch checked={Boolean(record.ready)} onClick={handleClick} />
+      }
+      label="Valmis julkaistavaksi"
+      labelPlacement="start"
+    />
+  );
+};
+
+const useEventShowActions = makeStyles(() => ({
+  toolbar: {
+    display: 'flex',
+  },
+  isReadyToggle: {
+    marginLeft: 'auto',
+  },
+}));
+
 const EventShowActions = ({
   basePath,
   data,
@@ -131,13 +174,16 @@ const EventShowActions = ({
   basePath?: string;
   data?: AdminEvent;
 }) => {
-  const hasData = Boolean(data);
   const hasEventGroup = Boolean(data?.eventGroup);
+  const classes = useEventShowActions();
 
   return (
     <TopToolbar>
       <EditButton basePath={basePath} record={data} />
-      {hasData && !hasEventGroup && <PublishButton record={data} />}
+      {data && !hasEventGroup && <PublishButton record={data} />}
+      {config.enableEventReadyTick && data && hasEventGroup && (
+        <IsReadyToggle className={classes.isReadyToggle} record={data} />
+      )}
     </TopToolbar>
   );
 };


### PR DESCRIPTION
## Description

Implements a button that can be used to mark an event as ready for publishing. Hides the button for now with a feature flag because it isn't yet integrated with the API.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-673](https://helsinkisolutionoffice.atlassian.net/browse/KK-673)

## How Has This Been Tested?

I'll cover this behaviour with an end to end test once the API is ready.

## Manual Testing Instructions for Reviewers

As a logged in user with `REACT_APP_ENABLE_EVENT_READY_TICK` set as turthy in my environment

1. Select event list
1. Select event group
1. Select event
1. Expect to be toggle for marking the event as ready
1. Go to event list
1. Select a "loose" event
1. Expect to not see a toggle ready button