### PR TITLE
KK-674 | Add status label to event list under event group

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,6 @@ See instructions in the sister project: https://github.com/City-of-Helsinki/kukk
 
 ## Feature Flags
 
-`REACT_APP_ENABLE_EVENT_READY_TICK`
+`REACT_APP_ENABLE_EVENT_READY_FEATURE`
 
-Can be used to toggle a toggle used for marking an event as ready on or off. At the time when this feature was first implemented, the API was not yet finalized so this feature could not be put live. In order to avoid leaving the code in an open branch indefinitely, a feature flag was used to toggle off the functionality until it can be integrated with the API.
+Can be used to toggle on the feature for making an event ready. At the time when this feature was first implemented, the API was not yet finalized so this feature could not be put live. In order to avoid leaving the code in an open branch indefinitely, a feature flag was used to toggle off the functionality until it can be integrated with the API.

--- a/src/common/components/localDataGrid/LocalDataGrid.tsx
+++ b/src/common/components/localDataGrid/LocalDataGrid.tsx
@@ -12,7 +12,6 @@ function disableSorting(field: ReactElement) {
     ...field,
     props: {
       ...field.props,
-
       sortable: false,
     },
   };
@@ -39,22 +38,26 @@ const LocalDataGrid = ({
     <Table className={classes.table} size="small">
       <TableHead className={classes.thead}>
         <TableRow className={[classes.row, classes.headerRow].join(' ')}>
-          {Children.map(children, (field, index) => (
-            <DatagridHeaderCell
-              className={classes.headerCell}
-              field={disableSorting(field)}
-              isSorting={false}
-              key={(field.props as any).source || index}
-              resource={resource}
-              currentSort={{
-                field: 'any',
-                order: 'ASC',
-              }}
-              updateSort={() => {
-                // pass
-              }}
-            />
-          ))}
+          {Children.map(
+            children,
+            (field, index) =>
+              field && (
+                <DatagridHeaderCell
+                  className={classes.headerCell}
+                  field={disableSorting(field)}
+                  isSorting={false}
+                  key={(field.props as any).source || index}
+                  resource={resource}
+                  currentSort={{
+                    field: 'any',
+                    order: 'ASC',
+                  }}
+                  updateSort={() => {
+                    // pass
+                  }}
+                />
+              )
+          )}
         </TableRow>
       </TableHead>
       <TableBody>

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -140,7 +140,12 @@
         "label": "Total capacity"
       },
       "ready": {
-        "label": "Ready to be published"
+        "label": "Ready to be published",
+        "label2": "Status",
+        "options": {
+          "ready": "Ready",
+          "notReady": "Unfinished"
+        }
       }
     },
     "list": {

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -141,7 +141,7 @@
       },
       "ready": {
         "label": "Valmis julkaistavaksi",
-        "label2": "Status",
+        "label2": "Tila",
         "options": {
           "ready": "Valmis",
           "notReady": "Keskeneräinen"

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -140,7 +140,12 @@
         "label": "Kokonaiskapasiteetti"
       },
       "ready": {
-        "label": "Valmis julkaistavaksi"
+        "label": "Valmis julkaistavaksi",
+        "label2": "Status",
+        "options": {
+          "ready": "Valmis",
+          "notReady": "Keskeneräinen"
+        }
       }
     },
     "list": {

--- a/src/domain/__tests__/config.test.js
+++ b/src/domain/__tests__/config.test.js
@@ -22,12 +22,12 @@ describe('Config', () => {
   });
 
   it('provides enableEventReadyTick', () => {
-    delete process.env.REACT_APP_ENABLE_EVENT_READY_TICK;
+    delete process.env.REACT_APP_ENABLE_EVENT_READY_FEATURE;
 
-    expect(Config.enableEventReadyTick).toBeFalsy();
+    expect(Config.enableEventReadyFeature).toEqual(false);
 
-    process.env.REACT_APP_ENABLE_EVENT_READY_TICK = 'true';
+    process.env.REACT_APP_ENABLE_EVENT_READY_FEATURE = 'true';
 
-    expect(Config.enableEventReadyTick).toBeTruthy();
+    expect(Config.enableEventReadyFeature).toEqual(true);
   });
 });

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -3,8 +3,8 @@ class Config {
     return process.env.NODE_ENV;
   }
 
-  static get enableEventReadyTick() {
-    return process.env.REACT_APP_ENABLE_EVENT_READY_TICK;
+  static get enableEventReadyFeature() {
+    return Boolean(process.env.REACT_APP_ENABLE_EVENT_READY_FEATURE);
   }
 }
 

--- a/src/domain/eventGroups/detail/EventGroupsDetail.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetail.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import {
   ResourceComponentPropsWithId,
-  TopToolbar,
   useTranslate,
-  CreateButton,
-  EditButton,
   TextField,
   NumberField,
   SelectField,
@@ -13,46 +10,27 @@ import {
 } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 
+import Config from '../../config';
 import { EventGroup_eventGroup_events_edges_node as EventNode } from '../../../api/generatedTypes/EventGroup';
 import KukkuuPageLayout from '../../application/layout/kukkuuPageLayout/KukkuuPageLayout';
 import KukkuuDetailPage from '../../application/layout/kukkuuDetailPage/KukkuuDetailPage';
 import LocalDataGrid from '../../../common/components/localDataGrid/LocalDataGrid';
 import { participantsPerInviteChoices } from '../../events/choices';
 import { countCapacity, countEnrollments } from '../../events/utils';
-import PublishEventGroupButton from './PublishEventGroupButton';
+import EventReadyField from './EventReadyField';
+import EventGroupsDetailActions from './EventGroupsDetailActions';
 
 const useStyles = makeStyles((theme) => ({
-  toolbar: {
-    margin: `0 -${theme.spacing(1)}px`,
-    '& > *': {
-      margin: `0 ${theme.spacing(1)}px`,
-    },
+  center: {
+    margin: '0 auto',
+    textAlign: 'center',
   },
 }));
-
-const EventGroupsDetailActions = ({ data, basePath }: any) => {
-  const t = useTranslate();
-  const classes = useStyles();
-
-  const isPublished = Boolean(data?.publishedAt);
-
-  return (
-    <TopToolbar className={classes.toolbar}>
-      <CreateButton
-        to={`/events/create?eventGroupId=${data?.id}`}
-        label={t('eventGroups.actions.addEvent.do')}
-      />
-      <EditButton basePath="/event-groups" record={data} />
-      {data && !isPublished && (
-        <PublishEventGroupButton basePath={basePath} record={data} />
-      )}
-    </TopToolbar>
-  );
-};
 
 const EventGroupsDetail = (props: ResourceComponentPropsWithId) => {
   const { history } = props;
   const t = useTranslate();
+  const classes = useStyles();
 
   const handleRowClick = (record?: Record) => {
     history?.push(`/events/${record?.id}/show`);
@@ -98,6 +76,15 @@ const EventGroupsDetail = (props: ResourceComponentPropsWithId) => {
           textAlign="right"
           render={(record?: Record) => countEnrollments(record as EventNode)}
         />
+        {Config.enableEventReadyFeature && (
+          <FunctionField
+            headerClassName={classes.center}
+            label="events.fields.ready.label2"
+            render={(record?: Record) => (
+              <EventReadyField record={record} className={classes.center} />
+            )}
+          />
+        )}
       </LocalDataGrid>
     </KukkuuDetailPage>
   );

--- a/src/domain/eventGroups/detail/EventGroupsDetailActions.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetailActions.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+  TopToolbar,
+  useTranslate,
+  CreateButton,
+  EditButton,
+} from 'react-admin';
+import { makeStyles } from '@material-ui/core';
+
+import PublishEventGroupButton from './PublishEventGroupButton';
+
+const useStyles = makeStyles((theme) => ({
+  toolbar: {
+    margin: `0 -${theme.spacing(1)}px`,
+    '& > *': {
+      margin: `0 ${theme.spacing(1)}px`,
+    },
+  },
+}));
+
+const EventGroupsDetailActions = ({ data, basePath }: any) => {
+  const t = useTranslate();
+  const classes = useStyles();
+
+  const isPublished = Boolean(data?.publishedAt);
+
+  return (
+    <TopToolbar className={classes.toolbar}>
+      <CreateButton
+        to={`/events/create?eventGroupId=${data?.id}`}
+        label={t('eventGroups.actions.addEvent.do')}
+      />
+      <EditButton basePath="/event-groups" record={data} />
+      {data && !isPublished && (
+        <PublishEventGroupButton basePath={basePath} record={data} />
+      )}
+    </TopToolbar>
+  );
+};
+
+export default EventGroupsDetailActions;

--- a/src/domain/eventGroups/detail/EventReadyField.tsx
+++ b/src/domain/eventGroups/detail/EventReadyField.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Record, useTranslate } from 'react-admin';
+import { makeStyles } from '@material-ui/core';
+import EditIcon from '@material-ui/icons/Edit';
+import CheckIcon from '@material-ui/icons/Check';
+
+const useStyles = makeStyles((theme) => ({
+  iconWithBackground: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '20px',
+    width: '20px',
+    color: '#fff',
+    borderRadius: '100%',
+    backgroundColor: theme.palette.grey[500],
+    '&.is-ready': {
+      backgroundColor: theme.palette.success.dark,
+    },
+  },
+}));
+
+type Props = {
+  record?: Record;
+  className: string;
+};
+
+const EventReadyField = ({ record, className }: Props) => {
+  const classes = useStyles();
+  const t = useTranslate();
+  const isReady = Boolean(record?.ready);
+  const classNames = [
+    classes.iconWithBackground,
+    isReady ? 'is-ready' : null,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classNames}>
+      {isReady && (
+        <CheckIcon
+          style={{ fontSize: 14 }}
+          titleAccess={t('events.fields.ready.options.ready')}
+          role="img"
+        />
+      )}
+      {!isReady && (
+        <EditIcon
+          style={{ fontSize: 14 }}
+          titleAccess={t('events.fields.ready.options.notReady')}
+          role="img"
+        />
+      )}
+    </div>
+  );
+};
+
+export default EventReadyField;

--- a/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
+++ b/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { TestContext } from 'react-admin';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '@material-ui/styles';
+import { createMuiTheme } from '@material-ui/core';
+
+import EventGroupsDetailActions from '../EventGroupsDetailActions';
+
+const defaultProps = {};
+const getWrapper = (props) =>
+  render(
+    <ThemeProvider theme={createMuiTheme()}>
+      <TestContext>
+        <EventGroupsDetailActions {...defaultProps} {...props} />
+      </TestContext>
+    </ThemeProvider>
+  );
+
+describe('<EventGroupsDetailActions />', () => {
+  it('should show a create button', () => {
+    const { getByRole } = getWrapper();
+
+    expect(
+      getByRole('button', { name: 'eventGroups.actions.addEvent.do' })
+    ).toBeTruthy();
+  });
+
+  it('should show an edit button', () => {
+    const { getByRole } = getWrapper();
+
+    expect(getByRole('button', { name: 'ra.action.edit' })).toBeTruthy();
+  });
+
+  it('should render a publish button when there is data', () => {
+    const { getByRole } = getWrapper({ data: {} });
+
+    expect(
+      getByRole('button', { name: 'eventGroups.actions.publish.do' })
+    ).toBeTruthy();
+  });
+
+  it('should hide publish button when the event group is already published', () => {
+    const { queryByRole } = getWrapper({
+      data: { publishedAt: new Date().toJSON() },
+    });
+
+    expect(
+      queryByRole('button', { name: 'eventGroups.actions.publish.do' })
+    ).toBeFalsy();
+  });
+});

--- a/src/domain/eventGroups/detail/__tests__/EventReadyField.test.jsx
+++ b/src/domain/eventGroups/detail/__tests__/EventReadyField.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import EventReadyField from '../EventReadyField';
+
+const defaultProps = {};
+const getWrapper = (props) =>
+  render(<EventReadyField {...defaultProps} {...props} />);
+
+describe('<EventReadyField />', () => {
+  it('should render ready when event is marked as ready', () => {
+    const { getByRole } = getWrapper({ record: { ready: true } });
+
+    expect(
+      getByRole('img', { name: 'events.fields.ready.options.ready' })
+    ).toBeTruthy();
+  });
+
+  it('should render not ready when event is not ready', () => {
+    const { getByRole } = getWrapper({ record: { ready: false } });
+
+    expect(
+      getByRole('img', { name: 'events.fields.ready.options.notReady' })
+    ).toBeTruthy();
+  });
+});

--- a/src/domain/events/detail/EventPublishButton.tsx
+++ b/src/domain/events/detail/EventPublishButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useTranslate } from 'react-admin';
+import PublishIcon from '@material-ui/icons/Check';
+
+import ConfirmMutationButton from '../../../common/components/confirmMutationButton/ConfirmMutationButton';
+import { AdminEvent } from '../types/EventTypes';
+
+type Props = {
+  record?: AdminEvent;
+  basePath?: string;
+};
+
+const EventPublishButton = ({ record, basePath = '/event' }: Props) => {
+  const translate = useTranslate();
+
+  return (
+    <ConfirmMutationButton
+      basePath={basePath}
+      buttonLabel="events.show.publish.button.label"
+      icon={<PublishIcon />}
+      successMessage="events.show.publish.onSuccess.message"
+      errorMessage="events.show.publish.onSuccess.message"
+      mutation={{
+        type: 'publish',
+        resource: 'events',
+        payload: { id: record?.id },
+      }}
+      confirmModalProps={{
+        title: translate('events.show.publish.confirm.title', {
+          eventName: record?.translations?.FI?.name,
+        }),
+        content: 'events.show.publish.confirm.content',
+      }}
+    />
+  );
+};
+
+export default EventPublishButton;

--- a/src/domain/events/detail/EventReadyToggle.tsx
+++ b/src/domain/events/detail/EventReadyToggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useMutation } from 'react-admin';
+import { useMutation, useTranslate } from 'react-admin';
 import Switch from '@material-ui/core/Switch';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
@@ -11,6 +11,7 @@ type Props = {
 };
 
 const EventReadyToggle = ({ record, className }: Props) => {
+  const t = useTranslate();
   const [setReady] = useMutation({
     type: 'setReady',
     resource: 'events',
@@ -29,7 +30,7 @@ const EventReadyToggle = ({ record, className }: Props) => {
         // @ts-ignore
         <Switch checked={Boolean(record.ready)} onClick={handleClick} />
       }
-      label="events.fields.ready.label"
+      label={t('events.fields.ready.label')}
       labelPlacement="start"
     />
   );

--- a/src/domain/events/detail/EventReadyToggle.tsx
+++ b/src/domain/events/detail/EventReadyToggle.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useMutation } from 'react-admin';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+
+import { AdminEvent } from '../types/EventTypes';
+
+type Props = {
+  record: AdminEvent;
+  className?: string;
+};
+
+const EventReadyToggle = ({ record, className }: Props) => {
+  const [setReady] = useMutation({
+    type: 'setReady',
+    resource: 'events',
+    payload: { id: record.id },
+  });
+
+  const handleClick = () => {
+    setReady();
+  };
+
+  return (
+    <FormControlLabel
+      className={className}
+      control={
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        <Switch checked={Boolean(record.ready)} onClick={handleClick} />
+      }
+      label="events.fields.ready.label"
+      labelPlacement="start"
+    />
+  );
+};
+
+export default EventReadyToggle;

--- a/src/domain/events/detail/EventShowActions.tsx
+++ b/src/domain/events/detail/EventShowActions.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { EditButton, TopToolbar } from 'react-admin';
+import { makeStyles } from '@material-ui/core';
+
+import Config from '../../config';
+import { AdminEvent } from '../types/EventTypes';
+import EventReadyToggle from './EventReadyToggle';
+import EventPublishButton from './EventPublishButton';
+
+const useStyles = makeStyles(() => ({
+  toolbar: {
+    display: 'flex',
+  },
+  isReadyToggle: {
+    marginLeft: 'auto',
+  },
+}));
+
+type Props = {
+  basePath?: string;
+  data?: AdminEvent;
+};
+
+const EventShowActions = ({ basePath, data }: Props) => {
+  const hasEventGroup = Boolean(data?.eventGroup);
+  const isPublished = Boolean(data?.publishedAt);
+  const classes = useStyles();
+
+  return (
+    <TopToolbar>
+      <EditButton basePath={basePath} record={data} />
+      {data && !hasEventGroup && !isPublished && (
+        <EventPublishButton basePath={basePath} record={data} />
+      )}
+      {Config.enableEventReadyFeature && data && hasEventGroup && (
+        <EventReadyToggle className={classes.isReadyToggle} record={data} />
+      )}
+    </TopToolbar>
+  );
+};
+
+export default EventShowActions;

--- a/src/domain/events/detail/__tests__/EventShowActions.test.jsx
+++ b/src/domain/events/detail/__tests__/EventShowActions.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { TestContext } from 'react-admin';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '@material-ui/styles';
+import { createMuiTheme } from '@material-ui/core';
+
+import Config from '../../../config';
+import EventShowActions from '../EventShowActions';
+
+const defaultProps = {
+  data: {},
+};
+const getWrapper = (props) =>
+  render(
+    <ThemeProvider theme={createMuiTheme()}>
+      <TestContext>
+        <EventShowActions {...defaultProps} {...props} />
+      </TestContext>
+    </ThemeProvider>
+  );
+
+describe('<EventShowActions />', () => {
+  it('should render an edit button', () => {
+    const { getByRole } = getWrapper();
+
+    expect(getByRole('button', { name: 'ra.action.edit' })).toBeTruthy();
+  });
+
+  it('should render event publish button', () => {
+    const { getByRole } = getWrapper();
+
+    expect(
+      getByRole('button', { name: 'events.show.publish.button.label' })
+    ).toBeTruthy();
+  });
+
+  describe('when the event has an event group', () => {
+    const getWrapperWithEvent = (props) =>
+      getWrapper({
+        data: {
+          eventGroup: {},
+        },
+        ...props,
+      });
+
+    it('should hide the event publish button', () => {
+      const { queryByRole } = getWrapperWithEvent();
+
+      expect(
+        queryByRole('button', { name: 'events.show.publish.button.label' })
+      ).toBeFalsy();
+    });
+
+    it('should show a button for setting the event as ready', () => {
+      jest
+        .spyOn(Config, 'enableEventReadyFeature', 'get')
+        .mockReturnValueOnce(true);
+
+      const { getByLabelText } = getWrapperWithEvent();
+
+      expect(getByLabelText('events.fields.ready.label')).toBeTruthy();
+    });
+  });
+
+  describe('when the event is published', () => {
+    it('the publish button should be hidden', () => {
+      const { queryByRole } = getWrapper({
+        data: { publishedAt: new Date().toJSON() },
+      });
+
+      expect(
+        queryByRole('button', {
+          name: 'events.show.publish.button.label',
+        })
+      ).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a status label in event group event list which shows whether the event is ready for publishing. The feature is not yet connected to the API, so it doesn't work, but it should be easy to connect to the API once the API is provided for.

As chores I also refactored some event and event group views so that they would be easier to test without having to mock the API.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-674](https://helsinkisolutionoffice.atlassian.net/browse/KK-674)

## How Has This Been Tested?

I've added unit/integration level tests for UI components.

## Manual Testing Instructions for Reviewers

As a logged in user with `REACT_APP_ENABLE_EVENT_READY_FEATURE` set as true in the environment

1. Open event list
1. Select event group
1. Expect to see a "Status" column and for it to contain a pencil icon