### PR TITLE
Chore | Fix event group details throwing an error

### DIFF
--- a/src/common/components/localDataGrid/LocalDataGrid.tsx
+++ b/src/common/components/localDataGrid/LocalDataGrid.tsx
@@ -68,19 +68,23 @@ const LocalDataGrid = ({
             onClick={() => handleRowClick(localRecord)}
             className={rowClick ? classes.clickableRow : undefined}
           >
-            {React.Children.map(children, (field, index) => (
-              <DatagridCell
-                key={`${localRecord.id}-${
-                  (field.props as any).source || index
-                }`}
-                className={[
-                  `column-${(field.props as any).source}`,
-                  classes.rowCell,
-                ].join(' ')}
-                record={localRecord}
-                {...{ field, basePath, resource }}
-              />
-            ))}
+            {React.Children.map(
+              children,
+              (field, index) =>
+                field && (
+                  <DatagridCell
+                    key={`${localRecord.id}-${
+                      (field.props as any).source || index
+                    }`}
+                    className={[
+                      `column-${(field.props as any).source}`,
+                      classes.rowCell,
+                    ].join(' ')}
+                    record={localRecord}
+                    {...{ field, basePath, resource }}
+                  />
+                )
+            )}
           </TableRow>
         ))}
       </TableBody>

--- a/src/common/components/localDataGrid/__tests__/LocalDataGrid.test.js
+++ b/src/common/components/localDataGrid/__tests__/LocalDataGrid.test.js
@@ -55,5 +55,11 @@ describe('<LocalDataGrid />', () => {
 
       expect(rowClick).toHaveBeenCalledTimes(1);
     });
+
+    it('should not throw when it has an empty field', () => {
+      expect(() => {
+        render(<LocalDataGrid {...defaultProps}>{null}</LocalDataGrid>);
+      }).not.toThrowError();
+    });
   });
 });


### PR DESCRIPTION
## Description

The LocalDataGrid received a non-component child, which caused an error in the rendering logic. I broke this view in https://github.com/City-of-Helsinki/kukkuu-admin/pull/122

When the environment variable `REACT_APP_ENABLE_EVENT_READY_FEATURE` is toggled off, the `LocalDataGrid` component received a child that was falsy instead of a component as it expected.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-674](https://helsinkisolutionoffice.atlassian.net/browse/KK-674)

## How Has This Been Tested?

I added a unit level test that checks that the `LocalDataGrid` can handle falsy values.

## Manual Testing Instructions for Reviewers

As a logged in admin user

1. Go to event list
1. Select an event group
1. Expect view to not crash