### PR TITLE
KK-678 | Fix occurrence end time being rendered as null

### DIFF
--- a/src/domain/occurrences/Occurrence.ts
+++ b/src/domain/occurrences/Occurrence.ts
@@ -33,7 +33,7 @@ class Occurrence {
     const duration = this.occurrence.event.duration; // minutes
 
     if (!duration) {
-      return null;
+      return '';
     }
 
     const startTime = new Date(this.occurrence.time);

--- a/src/domain/occurrences/__tests__/Occurrence.test.js
+++ b/src/domain/occurrences/__tests__/Occurrence.test.js
@@ -28,6 +28,18 @@ describe('Occurrence helper class', () => {
       expect(occurrence.endTime).toMatchInlineSnapshot(`"03.30"`);
     });
 
+    it('endTime without duration', () => {
+      expect(
+        new Occurrence({
+          ...occurrenceData,
+          event: {
+            ...occurrenceData.event,
+            duration: null,
+          },
+        }).endTime
+      ).toMatchInlineSnapshot(`""`);
+    });
+
     it('duration', () => {
       expect(occurrence.duration).toMatchInlineSnapshot(`"03.00 - 03.30"`);
     });
@@ -41,7 +53,7 @@ describe('Occurrence helper class', () => {
       });
 
       expect(occurrenceWithoutDuration.duration).toMatchInlineSnapshot(
-        `"03.00 - null"`
+        `"03.00 - "`
       );
     });
 


### PR DESCRIPTION
## Description

Changes the rendering logic for end time to render an empty string instead of null when `occurrence.event.duration` is missing.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-678](https://helsinkisolutionoffice.atlassian.net/browse/KK-678)

## How Has This Been Tested?

I've updated and added a test case.

## Manual Testing Instructions for Reviewers

1. Select an event without a duration
1. Select occurrence tab
1. Expect to not see "null"