### PR TITLE
KK-676 | Add ready for publishing button for events in an event group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - View for adding an event to an event group
 - Breadcrumb to occurrence detail view
 - Event group publish button
+- Event ready button for event in an event group
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,3 @@ Travis is configured to run a cron job daily. The browser tests are hooked to th
 ## Debugging
 
 See instructions in the sister project: https://github.com/City-of-Helsinki/kukkuu-ui/
-
-## Feature Flags
-
-`REACT_APP_ENABLE_EVENT_READY_FEATURE`
-
-Can be used to toggle on the feature for making an event ready. At the time when this feature was first implemented, the API was not yet finalized so this feature could not be put live. In order to avoid leaving the code in an open branch indefinitely, a feature flag was used to toggle off the functionality until it can be integrated with the API.

--- a/src/api/generatedTypes/Event.ts
+++ b/src/api/generatedTypes/Event.ts
@@ -61,6 +61,7 @@ export interface Event_event {
   translations: Event_event_translations[];
   capacityPerOccurrence: number;
   publishedAt: any | null;
+  readyForEventGroupPublishing: boolean;
   eventGroup: Event_event_eventGroup | null;
   occurrences: Event_event_occurrences;
 }

--- a/src/api/generatedTypes/EventGroup.ts
+++ b/src/api/generatedTypes/EventGroup.ts
@@ -52,6 +52,7 @@ export interface EventGroup_eventGroup_events_edges_node {
   duration: number | null;
   capacityPerOccurrence: number;
   publishedAt: any | null;
+  readyForEventGroupPublishing: boolean;
   occurrences: EventGroup_eventGroup_events_edges_node_occurrences;
 }
 

--- a/src/api/generatedTypes/EventGroupEventFragment.ts
+++ b/src/api/generatedTypes/EventGroupEventFragment.ts
@@ -45,5 +45,6 @@ export interface EventGroupEventFragment {
   duration: number | null;
   capacityPerOccurrence: number;
   publishedAt: any | null;
+  readyForEventGroupPublishing: boolean;
   occurrences: EventGroupEventFragment_occurrences;
 }

--- a/src/api/generatedTypes/UpdateEvent.ts
+++ b/src/api/generatedTypes/UpdateEvent.ts
@@ -50,6 +50,7 @@ export interface UpdateEvent_updateEvent_event {
    * In minutes
    */
   duration: number | null;
+  readyForEventGroupPublishing: boolean;
   translations: UpdateEvent_updateEvent_event_translations[];
   occurrences: UpdateEvent_updateEvent_event_occurrences;
 }

--- a/src/api/generatedTypes/globalTypes.ts
+++ b/src/api/generatedTypes/globalTypes.ts
@@ -54,6 +54,7 @@ export interface AddEventMutationInput {
   image?: any | null;
   projectId: string;
   eventGroupId?: string | null;
+  readyForEventGroupPublishing?: boolean | null;
   clientMutationId?: string | null;
 }
 
@@ -166,6 +167,7 @@ export interface UpdateEventMutationInput {
   translations?: (EventTranslationsInput | null)[] | null;
   projectId?: string | null;
   eventGroupId?: string | null;
+  readyForEventGroupPublishing?: boolean | null;
   clientMutationId?: string | null;
 }
 

--- a/src/common/components/confirmMutationButton/ConfirmMutationButton.tsx
+++ b/src/common/components/confirmMutationButton/ConfirmMutationButton.tsx
@@ -12,7 +12,7 @@ type Props = {
   buttonLabel: string;
   mutation: Mutation;
   successMessage: string;
-  errorMessage: string;
+  errorMessage: string | ((error: Error) => string);
   confirmModalProps: {
     title: string;
     content: string;
@@ -27,7 +27,7 @@ const ConfirmMutationButton = ({
   buttonLabel,
   mutation,
   successMessage,
-  errorMessage,
+  errorMessage: errorMessageSource,
   confirmModalProps: { title, content, translateOptions },
   icon: Icon,
 }: Props) => {
@@ -40,6 +40,12 @@ const ConfirmMutationButton = ({
     },
     onFailure: (error: Error) => {
       Sentry.captureException(error);
+
+      const errorMessage =
+        typeof errorMessageSource === 'string'
+          ? errorMessageSource
+          : errorMessageSource(error);
+
       notify(errorMessage, 'warning');
     },
   });

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -185,6 +185,7 @@
         "do": "Publish Event Group",
         "success": "Event group published!",
         "error": "Event group publish error",
+        "eventsNotReadyError": "All events are not ready for event group publishing.",
         "confirm": {
           "title": "Publish event group \"%{eventGroupName}\"",
           "content": "Are you sure that you want to publish this event group?"

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -185,7 +185,7 @@
         "do": "Julkaise tapahtumaryhmä",
         "success": "Tapahtumaryhmä julkaistu!",
         "error": "Tapahtumaryhmän julkaisussa tapahtui virhe.",
-        "eventsNotReadyError": "Kaikki tapahtumat eivät ole valmiit julkaisua varten.",
+        "eventsNotReadyError": "Kaikki tapahtumat eivät ole valmiita julkaisua varten.",
         "confirm": {
           "title": "Julkaise tapahtumaryhmä \"%{eventGroupName}\"",
           "content": "Oletko varma, että haluat julkaista tämän tapahtumaryhmän?"

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -185,6 +185,7 @@
         "do": "Julkaise tapahtumaryhmä",
         "success": "Tapahtumaryhmä julkaistu!",
         "error": "Tapahtumaryhmän julkaisussa tapahtui virhe.",
+        "eventsNotReadyError": "Kaikki tapahtumat eivät ole valmiit julkaisua varten.",
         "confirm": {
           "title": "Julkaise tapahtumaryhmä \"%{eventGroupName}\"",
           "content": "Oletko varma, että haluat julkaista tämän tapahtumaryhmän?"

--- a/src/domain/__tests__/config.test.js
+++ b/src/domain/__tests__/config.test.js
@@ -20,14 +20,4 @@ describe('Config', () => {
 
     expect(Config.NODE_ENV).toEqual('development');
   });
-
-  it('provides enableEventReadyTick', () => {
-    delete process.env.REACT_APP_ENABLE_EVENT_READY_FEATURE;
-
-    expect(Config.enableEventReadyFeature).toEqual(false);
-
-    process.env.REACT_APP_ENABLE_EVENT_READY_FEATURE = 'true';
-
-    expect(Config.enableEventReadyFeature).toEqual(true);
-  });
 });

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -2,10 +2,6 @@ class Config {
   static get NODE_ENV() {
     return process.env.NODE_ENV;
   }
-
-  static get enableEventReadyFeature() {
-    return Boolean(process.env.REACT_APP_ENABLE_EVENT_READY_FEATURE);
-  }
 }
 
 export default Config;

--- a/src/domain/eventGroups/detail/EventGroupsDetail.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetail.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 
-import Config from '../../config';
 import { EventGroup_eventGroup_events_edges_node as EventNode } from '../../../api/generatedTypes/EventGroup';
 import KukkuuPageLayout from '../../application/layout/kukkuuPageLayout/KukkuuPageLayout';
 import KukkuuDetailPage from '../../application/layout/kukkuuDetailPage/KukkuuDetailPage';
@@ -20,7 +19,7 @@ import { countCapacity, countEnrollments } from '../../events/utils';
 import EventReadyField from './EventReadyField';
 import EventGroupsDetailActions from './EventGroupsDetailActions';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   center: {
     margin: '0 auto',
     textAlign: 'center',
@@ -76,15 +75,13 @@ const EventGroupsDetail = (props: ResourceComponentPropsWithId) => {
           textAlign="right"
           render={(record?: Record) => countEnrollments(record as EventNode)}
         />
-        {Config.enableEventReadyFeature && (
-          <FunctionField
-            headerClassName={classes.center}
-            label="events.fields.ready.label2"
-            render={(record?: Record) => (
-              <EventReadyField record={record} className={classes.center} />
-            )}
-          />
-        )}
+        <FunctionField
+          headerClassName={classes.center}
+          label="events.fields.ready.label2"
+          render={(record?: Record) => (
+            <EventReadyField record={record} className={classes.center} />
+          )}
+        />
       </LocalDataGrid>
     </KukkuuDetailPage>
   );

--- a/src/domain/eventGroups/detail/EventReadyField.tsx
+++ b/src/domain/eventGroups/detail/EventReadyField.tsx
@@ -28,7 +28,7 @@ type Props = {
 const EventReadyField = ({ record, className }: Props) => {
   const classes = useStyles();
   const t = useTranslate();
-  const isReady = Boolean(record?.ready);
+  const isReady = Boolean(record?.readyForEventGroupPublishing);
   const classNames = [
     classes.iconWithBackground,
     isReady ? 'is-ready' : null,

--- a/src/domain/eventGroups/detail/PublishEventGroupButton.tsx
+++ b/src/domain/eventGroups/detail/PublishEventGroupButton.tsx
@@ -18,6 +18,16 @@ type Props = {
 const PublishEventGroupButton = ({ basePath, record, className }: Props) => {
   const t = useTranslate();
 
+  const handleErrorMessage = (error: Error) => {
+    if (
+      error.message === 'All events are not ready for event group publishing.'
+    ) {
+      return 'eventGroups.actions.publish.eventsNotReadyError';
+    }
+
+    return 'eventGroups.actions.publish.error';
+  };
+
   return (
     <ConfirmMutationButton
       basePath={basePath}
@@ -25,7 +35,7 @@ const PublishEventGroupButton = ({ basePath, record, className }: Props) => {
       buttonLabel="eventGroups.actions.publish.do"
       icon={<SendIcon />}
       successMessage="eventGroups.actions.publish.success"
-      errorMessage="eventGroups.actions.publish.error"
+      errorMessage={handleErrorMessage}
       mutation={{
         type: 'publish',
         resource: 'event-groups',

--- a/src/domain/eventGroups/detail/__tests__/EventReadyField.test.jsx
+++ b/src/domain/eventGroups/detail/__tests__/EventReadyField.test.jsx
@@ -9,7 +9,9 @@ const getWrapper = (props) =>
 
 describe('<EventReadyField />', () => {
   it('should render ready when event is marked as ready', () => {
-    const { getByRole } = getWrapper({ record: { ready: true } });
+    const { getByRole } = getWrapper({
+      record: { readyForEventGroupPublishing: true },
+    });
 
     expect(
       getByRole('img', { name: 'events.fields.ready.options.ready' })
@@ -17,7 +19,9 @@ describe('<EventReadyField />', () => {
   });
 
   it('should render not ready when event is not ready', () => {
-    const { getByRole } = getWrapper({ record: { ready: false } });
+    const { getByRole } = getWrapper({
+      record: { readyForEventGroupPublishing: false },
+    });
 
     expect(
       getByRole('img', { name: 'events.fields.ready.options.notReady' })

--- a/src/domain/eventGroups/queries/EvenGroupQueries.ts
+++ b/src/domain/eventGroups/queries/EvenGroupQueries.ts
@@ -10,6 +10,7 @@ const EventGroupEventFragment = gql`
     capacityPerOccurrence
     publishedAt
     duration
+    readyForEventGroupPublishing
     occurrences {
       edges {
         node {

--- a/src/domain/events/api/EventApi.ts
+++ b/src/domain/events/api/EventApi.ts
@@ -90,7 +90,18 @@ const deleteEvent: MethodHandler = async (params: MethodHandlerParams) => {
 };
 
 const setReady: MethodHandler = async (params: MethodHandlerParams) => {
-  return Promise.resolve(null);
+  const { id, readyForEventGroupPublishing } = params;
+  const response = await mutationHandler({
+    mutation: updateEventMutation,
+    variables: {
+      input: {
+        id,
+        readyForEventGroupPublishing,
+      },
+    },
+  });
+
+  return handleApiNode(response.data?.updateEvent.event);
 };
 
 export {

--- a/src/domain/events/detail/EventReadyToggle.tsx
+++ b/src/domain/events/detail/EventReadyToggle.tsx
@@ -1,9 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useMutation, useTranslate } from 'react-admin';
 import Switch from '@material-ui/core/Switch';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 import { AdminEvent } from '../types/EventTypes';
+
+function getReadyStatus(
+  readyInitial: boolean,
+  readyLocal: boolean,
+  loading: boolean,
+  readyRemote?: boolean
+): boolean {
+  if (readyRemote !== undefined) {
+    return readyRemote;
+  }
+
+  if (loading) {
+    return readyLocal;
+  }
+
+  return readyInitial;
+}
 
 type Props = {
   record: AdminEvent;
@@ -12,23 +29,35 @@ type Props = {
 
 const EventReadyToggle = ({ record, className }: Props) => {
   const t = useTranslate();
-  const [setReady] = useMutation({
-    type: 'setReady',
-    resource: 'events',
-    payload: { id: record.id },
-  });
+  const [isReadyLocal, setReadyLocal] = useState(
+    record.readyForEventGroupPublishing
+  );
+  const [setReady, { data, loading }] = useMutation();
+
+  const readyForEventGroupPublishing = getReadyStatus(
+    record.readyForEventGroupPublishing,
+    isReadyLocal,
+    loading,
+    data?.readyForEventGroupPublishing
+  );
 
   const handleClick = () => {
-    setReady();
+    setReadyLocal(!readyForEventGroupPublishing);
+    setReady({
+      type: 'setReady',
+      resource: 'events',
+      payload: {
+        id: record.id,
+        readyForEventGroupPublishing: !readyForEventGroupPublishing,
+      },
+    });
   };
 
   return (
     <FormControlLabel
       className={className}
       control={
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
-        <Switch checked={Boolean(record.ready)} onClick={handleClick} />
+        <Switch checked={readyForEventGroupPublishing} onClick={handleClick} />
       }
       label={t('events.fields.ready.label')}
       labelPlacement="start"

--- a/src/domain/events/detail/EventShowActions.tsx
+++ b/src/domain/events/detail/EventShowActions.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { EditButton, TopToolbar } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 
-import Config from '../../config';
 import { AdminEvent } from '../types/EventTypes';
 import EventReadyToggle from './EventReadyToggle';
 import EventPublishButton from './EventPublishButton';
@@ -32,7 +31,7 @@ const EventShowActions = ({ basePath, data }: Props) => {
       {data && !hasEventGroup && !isPublished && (
         <EventPublishButton basePath={basePath} record={data} />
       )}
-      {Config.enableEventReadyFeature && data && hasEventGroup && (
+      {data && hasEventGroup && !isPublished && (
         <EventReadyToggle className={classes.isReadyToggle} record={data} />
       )}
     </TopToolbar>

--- a/src/domain/events/detail/__tests__/EventReadyToggle.test.jsx
+++ b/src/domain/events/detail/__tests__/EventReadyToggle.test.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { TestContext, DataProviderContext } from 'react-admin';
+
+import EventReadyToggle from '../EventReadyToggle';
+
+const defaultProps = {
+  record: {
+    readyForEventGroupPublishing: false,
+  },
+};
+const getWrapper = (props, result = true) =>
+  render(
+    <DataProviderContext.Provider
+      value={{
+        setReady: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+
+          return {
+            data: {
+              readyForEventGroupPublishing: result,
+            },
+          };
+        },
+      }}
+    >
+      <TestContext>
+        <EventReadyToggle {...defaultProps} {...props} />
+      </TestContext>
+    </DataProviderContext.Provider>
+  );
+
+const getInput = ({ getByLabelText }) =>
+  getByLabelText('events.fields.ready.label');
+
+describe('<EventReadyToggle />', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should use the value it finds from the record as a default value', () => {
+    const wrapper = getWrapper({
+      record: {
+        readyForEventGroupPublishing: true,
+      },
+    });
+
+    expect(getInput(wrapper)).toHaveProperty('checked', true);
+  });
+
+  it('when the user clicks it should instantly change states', () => {
+    const wrapper = getWrapper();
+
+    expect(getInput(wrapper)).toHaveProperty('checked', false);
+
+    fireEvent.click(getInput(wrapper));
+
+    expect(getInput(wrapper)).toHaveProperty('checked', true);
+  });
+
+  it('should use the result it receives in the response as soon as it is available', async () => {
+    const wrapper = getWrapper({}, false);
+
+    fireEvent.click(getInput(wrapper));
+
+    expect(getInput(wrapper)).toHaveProperty('checked', true);
+
+    await waitFor(() =>
+      expect(getInput(wrapper)).toHaveProperty('checked', false)
+    );
+  });
+});

--- a/src/domain/events/detail/__tests__/EventShowActions.test.jsx
+++ b/src/domain/events/detail/__tests__/EventShowActions.test.jsx
@@ -4,7 +4,6 @@ import { render } from '@testing-library/react';
 import { ThemeProvider } from '@material-ui/styles';
 import { createMuiTheme } from '@material-ui/core';
 
-import Config from '../../../config';
 import EventShowActions from '../EventShowActions';
 
 const defaultProps = {
@@ -38,7 +37,10 @@ describe('<EventShowActions />', () => {
     const getWrapperWithEvent = (props) =>
       getWrapper({
         data: {
-          eventGroup: {},
+          eventGroup: {
+            readyForEventGroupPublishing: true,
+            publishedAt: new Date(),
+          },
         },
         ...props,
       });
@@ -52,10 +54,6 @@ describe('<EventShowActions />', () => {
     });
 
     it('should show a button for setting the event as ready', () => {
-      jest
-        .spyOn(Config, 'enableEventReadyFeature', 'get')
-        .mockReturnValueOnce(true);
-
       const { getByLabelText } = getWrapperWithEvent();
 
       expect(getByLabelText('events.fields.ready.label')).toBeTruthy();
@@ -73,6 +71,17 @@ describe('<EventShowActions />', () => {
           name: 'events.show.publish.button.label',
         })
       ).toBeFalsy();
+    });
+
+    it('the set ready button should be hidden', () => {
+      const { queryByLabelText } = getWrapper({
+        data: {
+          readyForEventGroupPublishing: true,
+          publishedAt: new Date().toJSON(),
+        },
+      });
+
+      expect(queryByLabelText('events.fields.ready.label')).toBeFalsy();
     });
   });
 });

--- a/src/domain/events/mutations/EventMutations.ts
+++ b/src/domain/events/mutations/EventMutations.ts
@@ -30,6 +30,7 @@ export const updateEventMutation = gql`
         participantsPerInvite
         capacityPerOccurrence
         duration
+        readyForEventGroupPublishing
         translations {
           imageAltText
           languageCode

--- a/src/domain/events/queries/EventQueries.ts
+++ b/src/domain/events/queries/EventQueries.ts
@@ -49,6 +49,7 @@ export const eventQuery = gql`
       }
       capacityPerOccurrence
       publishedAt
+      readyForEventGroupPublishing
       eventGroup {
         id
         name

--- a/src/domain/events/types/EventTypes.ts
+++ b/src/domain/events/types/EventTypes.ts
@@ -11,4 +11,5 @@ export interface AdminEvent {
   publishedAt?: string;
   translations: AdminUITranslation<Omit<ApiEventTranslation, 'languageCode'>>;
   eventGroup?: EventGroup;
+  readyForEventGroupPublishing: boolean;
 }


### PR DESCRIPTION
## Description

Finalises the functionality implemented partially in previous PRs.

- The publish toggle is only shown for events that belong to an event group and is not yet published
- The publish toggle sends an update mutation which sets the `readyForEventGroupPublishing` field
    - The toggle should toggle right away
    - The toggle should apply its state based on the result it receives from the server as soon as it's available
 - Changes in event's ready state should be reflected in the event group event list view
 - If event group publishing fails because some of its events are not published, a special error message is shown

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-676](https://helsinkisolutionoffice.atlassian.net/browse/KK-676)

## How Has This Been Tested?

I've added unit tests that cover the new functionality.

## Manual Testing Instructions for Reviewers

As a logged in user

1. Access event list
2. Select an unpublished event group
3. Add or select an existing non-ready event
4. Toggle the event as ready
5. Go back to event group
6. Expect the event to be marked as ready