### PR TITLE
Chore | Don't build production on master merges

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,6 @@ build-production:
     DOCKER_BUILD_ARG_REACT_APP_SENTRY_DSN: 'https://c89ee3f57dc94ffd940d1df1a353b97f@sentry.hel.ninja/55'
   only:
     refs:
-      - master
       # this regexp will match release-tags
       - /^release-.*$/
 


### PR DESCRIPTION
## Description

It seems that there aren't enough resources to have two builds running at the same time because one of the tasks exists with the code 137 which can mean manual kill or an out of memory error. Either there are not enough resources or then maybe the completion of one task exits the other.

The staging version will still be built on master merges. As far as I know it's mostly similar with the staging build. Some configuration does differ.