### PR TITLE
KK-696 | Fix unauthorized page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - Use GitHub flow instead of GitFlow
 
+### Fixed
+
+- Authorization check
+- Unauthorized view styles
+
 ## [1.5.0] - 2020-12-17
 
 ### Added

--- a/browser-tests/pages/unauthorized.ts
+++ b/browser-tests/pages/unauthorized.ts
@@ -1,0 +1,6 @@
+import { screen } from '@testing-library/testcafe';
+
+export const unauthorized = {
+  title: screen.getByText('Ei käyttöoikeutta'),
+  logout: screen.getByRole('button', { name: 'Kirjaudu ulos'  }),
+};

--- a/browser-tests/unauthorizedFeature.ts
+++ b/browser-tests/unauthorizedFeature.ts
@@ -1,0 +1,22 @@
+import {
+  testUnauthorizedUsername,
+  testUnauthorizedUserPassword,
+} from './utils/settings';
+import { routes } from './pages/routes';
+import { login } from './utils/login';
+import { unauthorized } from './pages/unauthorized';
+
+fixture`Unauthorized feature`
+  .page(routes.eventsList())
+  .beforeEach(async (t) => {
+    await login(t, {
+      username: testUnauthorizedUsername(),
+      password: testUnauthorizedUserPassword(),
+    });
+    await t.wait(1000);
+  });
+
+test('As a user without admin permissions I want to see an unauthorized page', async (t) => {
+  await t.expect(unauthorized.title.exists).ok();
+  await t.expect(unauthorized.logout.exists).ok();
+});

--- a/browser-tests/utils/login.ts
+++ b/browser-tests/utils/login.ts
@@ -2,12 +2,18 @@ import { ssoLogin } from '../pages/ssoLogin';
 import { login as loginPage } from '../pages/login';
 import { testUsername, testUserPassword } from './settings';
 
-export const login = async (t: TestController) => {
+type Options = {
+  username?: string;
+  password?: string;
+}
+
+export const login = async (t: TestController, options: Options = {}) => {
+  const { username = testUsername(), password = testUserPassword()} = options;
   await t
     .click(loginPage.loginButton)
     .click(ssoLogin.loginLink)
-    .typeText(ssoLogin.username, testUsername())
-    .typeText(ssoLogin.password, testUserPassword())
+    .typeText(ssoLogin.username, username)
+    .typeText(ssoLogin.password, password)
     .click(ssoLogin.loginButton)
     // Wait for authorization to finish
     .wait(3000); // 3s

--- a/browser-tests/utils/settings.ts
+++ b/browser-tests/utils/settings.ts
@@ -1,24 +1,28 @@
 import * as dotenv from 'dotenv';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const get = require('lodash/get');
+
 dotenv.config();
 
-export const testUsername = (): string => {
-  if (!process.env.BROWSER_TESTS_UID) {
-    throw new Error('No BROWSER_TESTS_UID specified.');
-  }
-  return process.env.BROWSER_TESTS_UID;
-};
+function getOrError(variableName: string) {
+  const variable = get(process.env, variableName);
 
-export const testUserPassword = (): string => {
-  if (!process.env.BROWSER_TESTS_PWD) {
-    throw new Error('No BROWSER_TESTS_PWD specified.');
+  if (!variable) {
+    throw new Error(`No ${variableName} specified.`);
   }
-  return process.env.BROWSER_TESTS_PWD;
-};
 
-export const envUrl = (): string => {
-  if (!process.env.BROWSER_TESTS_ENV_URL) {
-    throw new Error('No BROWSER_ENV_URL specified.');
-  }
-  return process.env.BROWSER_TESTS_ENV_URL;
-};
+  return variable;
+}
+
+export const testUsername = (): string => getOrError('BROWSER_TESTS_UID');
+
+export const testUserPassword = (): string => getOrError('BROWSER_TESTS_PWD');
+
+export const testUnauthorizedUsername = (): string =>
+  getOrError('BROWSER_TESTS_UNAUTHORIZED_UID');
+
+export const testUnauthorizedUserPassword = (): string =>
+  getOrError('BROWSER_TESTS_UNAUTHORIZED_PWD');
+
+export const envUrl = (): string => getOrError('BROWSER_TESTS_ENV_URL');

--- a/src/domain/application/App.tsx
+++ b/src/domain/application/App.tsx
@@ -22,7 +22,7 @@ import EventGroupsResource from '../eventGroups/EventGroupsResource';
 import EventsAndEventGroupsResource from '../eventsAndEventGroups/EventsAndEventGroupsResource';
 import KukkuuLayout from './layout/kukkuuAppLayout/KukkuuAppLayout';
 
-const history = createHistory();
+export const history = createHistory();
 
 const App = () => {
   const translate = useTranslate();

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -25,7 +25,7 @@ function CallBackPage({ history }: RouteComponentProps) {
         const role = authorizationService.getRole();
 
         if (role === 'none') {
-          history.push('/unauthorized');
+          history.replace('/unauthorized');
         } else {
           history.replace(user?.state.path);
         }

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -10,6 +10,7 @@ import * as Sentry from '@sentry/browser';
 import { User } from 'oidc-client';
 
 import authService from './authService';
+import authorizationService from './authorizationService';
 
 function CallBackPage({ history }: RouteComponentProps) {
   const t = useTranslate();
@@ -21,7 +22,13 @@ function CallBackPage({ history }: RouteComponentProps) {
     authService
       .endLogin()
       .then((user: User) => {
-        history.replace(user?.state.path);
+        const role = authorizationService.getRole();
+
+        if (role === 'none') {
+          history.push('/unauthorized');
+        } else {
+          history.replace(user?.state.path);
+        }
       })
       .catch((error) => {
         notify(t('ra.message.error'), 'warning');

--- a/src/domain/authentication/UnauthorizedPage.tsx
+++ b/src/domain/authentication/UnauthorizedPage.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { useTranslate } from 'react-admin';
+import { useLogout, useTranslate } from 'react-admin';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import CardHeader from '@material-ui/core/CardHeader';
 import Container from '@material-ui/core/Container';
 import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
 
 const UnauthorizedPage = () => {
   const translate = useTranslate();
+  const logout = useLogout();
   const contactEmail = translate(
     'authentication.unauthorizedPage.contactEmail'
   );
@@ -21,9 +23,7 @@ const UnauthorizedPage = () => {
           {translate('authentication.unauthorizedPage.content')}{' '}
           <a href={'mailto:' + contactEmail}>{contactEmail}</a>
           <Box style={{ marginTop: '2rem' }}>
-            <a href="/login">
-              {translate('authentication.unauthorizedPage.backToLoginPage')}
-            </a>
+            <Button onClick={logout}>{translate('ra.auth.logout')}</Button>
           </Box>
         </CardContent>
       </Card>

--- a/src/domain/authentication/UnauthorizedPage.tsx
+++ b/src/domain/authentication/UnauthorizedPage.tsx
@@ -6,28 +6,52 @@ import CardHeader from '@material-ui/core/CardHeader';
 import Container from '@material-ui/core/Container';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
+import { ThemeProvider, makeStyles } from '@material-ui/styles';
+
+import theme from '../../common/materialUI/themeConfig';
+
+const useStyles = makeStyles(() => ({
+  background: {
+    height: '100vh',
+    width: '100vw',
+    display: 'flex',
+    justifyContent: 'center',
+    background:
+      'radial-gradient(circle at 50% 14em, #313264 0%, #00023b 60%, #00023b 100%)',
+  },
+  container: {
+    marginTop: '6em',
+  },
+}));
 
 const UnauthorizedPage = () => {
   const translate = useTranslate();
   const logout = useLogout();
+  const classes = useStyles();
   const contactEmail = translate(
     'authentication.unauthorizedPage.contactEmail'
   );
   return (
-    <Container maxWidth="sm">
-      <Card style={{ textAlign: 'center', marginTop: '2rem' }}>
-        <CardHeader
-          title={translate('authentication.unauthorizedPage.title')}
-        />
-        <CardContent>
-          {translate('authentication.unauthorizedPage.content')}{' '}
-          <a href={'mailto:' + contactEmail}>{contactEmail}</a>
-          <Box style={{ marginTop: '2rem' }}>
-            <Button onClick={logout}>{translate('ra.auth.logout')}</Button>
-          </Box>
-        </CardContent>
-      </Card>
-    </Container>
+    <ThemeProvider theme={theme}>
+      <div className={classes.background}>
+        <Container maxWidth="sm" className={classes.container}>
+          <Card style={{ textAlign: 'center' }}>
+            <CardHeader
+              title={translate('authentication.unauthorizedPage.title')}
+            />
+            <CardContent>
+              {translate('authentication.unauthorizedPage.content')}{' '}
+              <a href={'mailto:' + contactEmail}>{contactEmail}</a>
+              <Box style={{ marginTop: '2rem' }}>
+                <Button variant="contained" color="secondary" onClick={logout}>
+                  {translate('ra.auth.logout')}
+                </Button>
+              </Box>
+            </CardContent>
+          </Card>
+        </Container>
+      </div>
+    </ThemeProvider>
   );
 };
 export default UnauthorizedPage;

--- a/src/domain/authentication/__tests__/authProvider.test.js
+++ b/src/domain/authentication/__tests__/authProvider.test.js
@@ -1,3 +1,4 @@
+import { history } from '../../application/App';
 import profileService from '../../profile/profileService';
 import authProvider from '../authProvider';
 import authService from '../authService';
@@ -57,9 +58,12 @@ describe('authProvider', () => {
   });
 
   describe('checkAuth', () => {
-    it('should resolve when user is authenticated according to authService', () => {
+    it('should resolve when user is authenticated and authorized', () => {
       expect.assertions(1);
       jest.spyOn(authService, 'isAuthenticated').mockReturnValueOnce(true);
+      jest
+        .spyOn(authorizationService, 'isAuthorized')
+        .mockReturnValueOnce(true);
 
       return expect(authProvider.checkAuth()).resolves.toEqual();
     });
@@ -69,6 +73,20 @@ describe('authProvider', () => {
       jest.spyOn(authService, 'isAuthenticated').mockReturnValueOnce(false);
 
       return expect(authProvider.checkAuth()).rejects.toEqual();
+    });
+
+    it('should redirect when the use is authenticated, authorized but not an admin', async () => {
+      expect.assertions(2);
+      jest.spyOn(authService, 'isAuthenticated').mockReturnValueOnce(true);
+      jest
+        .spyOn(authorizationService, 'isAuthorized')
+        .mockReturnValueOnce(true);
+      jest.spyOn(authorizationService, 'getRole').mockReturnValueOnce('none');
+      const historySpy = jest.spyOn(history, 'replace');
+
+      await expect(authProvider.checkAuth()).resolves.toEqual();
+
+      expect(historySpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/domain/authentication/__tests__/authProvider.test.js
+++ b/src/domain/authentication/__tests__/authProvider.test.js
@@ -57,7 +57,7 @@ describe('authProvider', () => {
   });
 
   describe('checkAuth', () => {
-    it('should resolve when user is authenticated according to authService and the user has a project id', () => {
+    it('should resolve when user is authenticated according to authService', () => {
       expect.assertions(1);
       jest.spyOn(authService, 'isAuthenticated').mockReturnValueOnce(true);
 
@@ -88,14 +88,6 @@ describe('authProvider', () => {
 
       return expect(authProvider.checkError()).rejects.toEqual();
     });
-
-    it('should reject when user does not have project id', () => {
-      expect.assertions(1);
-      jest.spyOn(authService, 'getToken').mockReturnValueOnce(fakeToken);
-      projectIdSpy.mockReturnValueOnce();
-
-      return expect(authProvider.checkAuth()).rejects.toEqual();
-    });
   });
 
   describe('getPermissions', () => {
@@ -106,17 +98,6 @@ describe('authProvider', () => {
       jest.spyOn(authorizationService, 'getRole').mockReturnValue(role);
 
       return expect(authProvider.getPermissions()).resolves.toEqual(role);
-    });
-
-    it('should reject when permission is none', () => {
-      expect.assertions(1);
-      const role = 'none';
-
-      jest.spyOn(authorizationService, 'getRole').mockReturnValue(role);
-
-      return expect(authProvider.getPermissions()).rejects.toEqual({
-        redirectTo: '/unauthorized',
-      });
     });
   });
 });

--- a/src/domain/authentication/__tests__/authorizationService.test.js
+++ b/src/domain/authentication/__tests__/authorizationService.test.js
@@ -16,7 +16,11 @@ describe('authorizationService', () => {
     dataProviderSpy = jest
       .spyOn(dataProvider, 'getMyAdminProfile')
       .mockResolvedValue({
-        data: {},
+        data: {
+          projects: {
+            edges: [{ node: {} }],
+          },
+        },
       });
     profileServiceSpy = jest
       .spyOn(profileService, 'setDefaultProjectId')
@@ -38,7 +42,7 @@ describe('authorizationService', () => {
       expect(dataProviderSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should save admin role into session storage when getMyAdminProfile call works', async () => {
+    it('should save admin role into session storage when getMyAdminProfile call works and the profile has projects', async () => {
       expect.assertions(1);
 
       await authorizationService.fetchRole();
@@ -46,10 +50,14 @@ describe('authorizationService', () => {
       expect(sessionStorage.getItem(PERMISSIONS)).toEqual('admin');
     });
 
-    it('should save none role into session storage when getMyAdminProfile call fails', async () => {
+    it('should save none role into session storage when getMyAdminProfile returns a profile that does not have projects', async () => {
       expect.assertions(1);
 
-      dataProviderSpy.mockRejectedValue({});
+      dataProviderSpy.mockResolvedValue({
+        projects: {
+          edges: [],
+        },
+      });
 
       await authorizationService.fetchRole();
 

--- a/src/domain/authentication/authProvider.ts
+++ b/src/domain/authentication/authProvider.ts
@@ -1,6 +1,5 @@
 import { AuthProvider } from 'ra-core';
 
-import profileService from '../profile/profileService';
 import authService from './authService';
 import authorizationService from './authorizationService';
 
@@ -30,9 +29,8 @@ const authProvider: AuthProvider = {
   },
   checkError: () => {
     const hasTokens = Boolean(authService.getToken());
-    const hasProject = Boolean(profileService.projectId);
 
-    if (hasTokens && hasProject) {
+    if (hasTokens) {
       return Promise.resolve();
     }
 
@@ -40,13 +38,8 @@ const authProvider: AuthProvider = {
   },
   getPermissions: () => {
     const role = authorizationService.getRole();
-    const hasAuthorization = role === 'admin';
 
-    if (hasAuthorization) {
-      return Promise.resolve(role);
-    }
-
-    return Promise.reject({ redirectTo: '/unauthorized' });
+    return Promise.resolve(role);
   },
 };
 

--- a/src/domain/authentication/authProvider.ts
+++ b/src/domain/authentication/authProvider.ts
@@ -1,5 +1,6 @@
 import { AuthProvider } from 'ra-core';
 
+import { history } from '../application/App';
 import authService from './authService';
 import authorizationService from './authorizationService';
 
@@ -20,8 +21,20 @@ const authProvider: AuthProvider = {
   },
   checkAuth: () => {
     const isAuthenticated = authService.isAuthenticated();
+    const isAuthorized = authorizationService.isAuthorized();
+    const isAdmin = authorizationService.getRole() === 'admin';
+    const isAdminOrPermissionNotChecked =
+      isAuthenticated && (!isAuthorized || isAdmin);
+    const isNotAdmin = isAuthenticated && isAuthorized && !isAdmin;
 
-    if (isAuthenticated) {
+    if (isAdminOrPermissionNotChecked) {
+      return Promise.resolve();
+    }
+
+    if (isNotAdmin) {
+      history.replace('/unauthorized');
+
+      // Resolve promise so the user is not logged out
       return Promise.resolve();
     }
 

--- a/src/domain/authentication/authorizationService.ts
+++ b/src/domain/authentication/authorizationService.ts
@@ -19,9 +19,10 @@ export class AuthorizationService {
     try {
       const { data } = await dataProvider.getMyAdminProfile();
       const projects = ProjectList((data as any)?.projects).items;
+      const role = projects.length > 0 ? 'admin' : 'none';
 
       projectService.setDefaultProjectId(projects);
-      sessionStorage.setItem(PERMISSIONS, 'admin');
+      sessionStorage.setItem(PERMISSIONS, role);
     } catch (e) {
       sessionStorage.setItem(PERMISSIONS, 'none');
     }


### PR DESCRIPTION
## Description

Due to earlier permission changes, the permission check made within the UI was no longer functioning properly.

Since the change, an admin profile has been returned for all users. Before the change the profile was only returned for users that had permissions to access a project.

The styles for the unauthorized page had also been broken. Likely when `react-admin` was updated to a  newer version.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-696](https://helsinkisolutionoffice.atlassian.net/browse/KK-696)

## How Has This Been Tested?

I've added an e2e test that checks the unauthorized procedure.

## Manual Testing Instructions for Reviewers

As a user with permissions to access the admin

1. Login
2. Expect to be logged in

As a user without permission to access the admin

1. Login
2. Expect to be taken into the unauthorized page