### PR TITLE
KuVa Tunnistamo to use

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -19,16 +19,18 @@ jobs:
     name: Build
     steps:
       - uses: actions/checkout@v2
+      - uses: andersinno/kolga-setup-action@v2
+
       - name: Build
         uses: andersinno/kolga-build-action@v2
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-review
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'review'
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://tunnistamo.test.kuva.hel.ninja'
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://api.hel.fi/auth/kukkuu-admin-ui'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://tunnistamo.${{ env.BASE_DOMAIN }}'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: ${{ env.K8S_NAMESPACE }}
           DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid profile https://api.hel.fi/auth/kukkuu'
           DOCKER_BUILD_ARG_REACT_APP_KUKKUU_API_OIDC_SCOPE: 'https://api.hel.fi/auth/kukkuu'
-          DOCKER_BUILD_ARG_REACT_APP_API_URI: 'https://kukkuu.test.kuva.hel.ninja/graphql'
+          DOCKER_BUILD_ARG_REACT_APP_API_URI: 'https://kukkuu.${{ env.BASE_DOMAIN }}/graphql'
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_DSN: 'https://c89ee3f57dc94ffd940d1df1a353b97f@sentry.hel.ninja/55'
   
   review:
@@ -44,3 +46,10 @@ jobs:
         env:
           ENVIRONMENT_URL: https://${{ env.K8S_NAMESPACE }}.${{ env.BASE_DOMAIN }}
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-review
+
+      - name: Setup Tunnistamo
+        uses: City-of-Helsinki/setup-tunnistamo-action@main
+        with:
+          kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
+          review_namespace: ${{ env.K8S_NAMESPACE }}
+          api_scope: https://api.hel.fi/auth/kukkuu

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,6 +13,7 @@ env:
   KUBECONFIG_RAW: ${{ secrets.KUBECONFIG_RAW_STAGING }}
   BUILD_ARTIFACT_FOLDER: 'build_artifacts'
   SERVICE_ARTIFACT_FOLDER: 'service_artifacts'
+  BASE_DOMAIN: ${{ secrets.BASE_DOMAIN_STAGING }}
   SERVICE_PORT: 80
 
 jobs:
@@ -26,11 +27,11 @@ jobs:
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-staging
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'staging'
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://tunnistamo.test.kuva.hel.ninja'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://tunnistamo.${{ env.BASE_DOMAIN }}'
           DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://api.hel.fi/auth/kukkuu-admin-ui'
           DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid profile https://api.hel.fi/auth/kukkuu'
           DOCKER_BUILD_ARG_REACT_APP_KUKKUU_API_OIDC_SCOPE: 'https://api.hel.fi/auth/kukkuu'
-          DOCKER_BUILD_ARG_REACT_APP_API_URI: 'https://kukkuu.test.kuva.hel.ninja/graphql'
+          DOCKER_BUILD_ARG_REACT_APP_API_URI: 'https://kukkuu.${{ env.BASE_DOMAIN }}/graphql'
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_DSN: 'https://c89ee3f57dc94ffd940d1df1a353b97f@sentry.hel.ninja/55'
 
   staging:


### PR DESCRIPTION

## Context

Allows usage of Tunnistamo also at review environment(s)

[DEVOPS-227](https://helsinkisolutionoffice.atlassian.net/browse/DEVOPS-227)

## How Has This Been Tested?

Implemented to open-city-profile-ui, and tested also in created review env manually.

## Manual Testing Instructions for Reviewers

Access review env and sign in.