### PR TITLE
KK-706 | Do not sanitize event editing form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Application title
 
+### Fixed
+
+- Event editing leading to an error when user set a non-required string value as empty
+
 ## [1.5.1] - 2021-01-19
 
 ### Added

--- a/src/domain/events/edit/EventEdit.tsx
+++ b/src/domain/events/edit/EventEdit.tsx
@@ -53,6 +53,7 @@ const EventEdit = (props: any) => {
             // @ts-ignore
             validate={validateVenue}
             toolbar={<EventEditToolbar />}
+            sanitizeEmptyValues={false}
           >
             <ViewTitle source={'events.edit.title'} />
             <LanguageTabs


### PR DESCRIPTION
## Description

The backend expects empty strings instead of null values. By default react-admin sanitizes form values, which transforms empty strings `""` into null.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-706](https://helsinkisolutionoffice.atlassian.net/browse/KK-706)

## How Has This Been Tested?

I've tested this manually by checking that the event edit form no longer returns an error when I attempt to update an event that has a short description to have none.

## Manual Testing Instructions for Reviewers

Access an event with a short description

1. Remove short description
2. Save
3. Expect to see no error message