### PR TITLE
KK-707 | Fix LongTextField label in a SimpleShow layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Application title
 - Distinct test environment from production environment
 
+### Fixed
+
+- Missing labels in venue and event detail views
+
 ## [1.5.1] - 2021-01-19
 
 ### Added

--- a/src/common/components/longTextField/LongTextField.tsx
+++ b/src/common/components/longTextField/LongTextField.tsx
@@ -11,4 +11,10 @@ const LongTextField = (props: any) => {
   return <TextField className={classes.longTextField} {...props} />;
 };
 
+LongTextField.defaultProps = {
+  // SimpleShowLayout wraps its children in a <Label /> if the child has
+  // its addLabel prop set to true.
+  addLabel: true,
+};
+
 export default LongTextField;


### PR DESCRIPTION
## Description

Previously the custom `<LongTextField />` would not show a label. This was due to the logic in `react-admin`'s `SimpleShowLayout` which only wraps those children that have `addLabel` set to `true`.

The fix here was to add `addLabel` as a default prop for `LongTextField`.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-707](https://helsinkisolutionoffice.atlassian.net/browse/KK-707)

## How Has This Been Tested?

I've tested this change manually.

## Manual Testing Instructions for Reviewers

1. Go to venues
2. Select a venue that has all its fields filled
3. Expect all of its fields to have a label