### PR TITLE
KK-709 | Remove helper text that does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Missing labels in venue and event detail views
 
+### Removed
+
+- Helper text from venue amenities field
+
 ## [1.5.1] - 2021-01-19
 
 ### Added

--- a/src/domain/venues/VenueCreate.tsx
+++ b/src/domain/venues/VenueCreate.tsx
@@ -78,7 +78,6 @@ const VenueCreate = (props: any) => {
           <TextInput
             source={`${translation}.wcAndFacilities`}
             label="venues.fields.wcAndFacilities.label"
-            helperText="venues.fields.wcAndFacilities.helperText"
             multiline
             fullWidth
           />


### PR DESCRIPTION
## Description

This helper text seems like it has never had a translation. Because it does not have a translation, it makes the UI appear broken.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-709](https://helsinkisolutionoffice.atlassian.net/browse/KK-709)

## How Has This Been Tested?

I've manually checked that the broken helper text is no longer shown.

## Manual Testing Instructions for Reviewers

1. Go to venue creation view
2. Expect to see no broken helper text