### PR TITLE
KK-708 | Fix slowly updating deleted events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Missing labels in venue and event detail views
+- Fix slow update od event and event group list by using confirmation pattern instead of undo pattern when deleting events
 
 ## [1.5.1] - 2021-01-19
 

--- a/browser-tests/pages/events.ts
+++ b/browser-tests/pages/events.ts
@@ -42,6 +42,7 @@ export const eventsCreatePage = {
 export const eventsEditPage = {
   ...eventForm,
   deleteButton: screen.getAllByRole('button', { name: 'Poista' }).nth(1),
+  confirmDeleteButton: screen.getByRole('button', { name: 'Vahvista' }),
 };
 
 type CreateEvent = {
@@ -70,10 +71,9 @@ export async function deleteEvent(t: TestController) {
   // Delete the event
   await t.click(eventsEditPage.deleteButton);
 
-  // Click anywhere on the page to cancel the undo waiting time for
-  // completing the action
-  await t.click(eventsListPage.title);
+  // Confirm the delete
+  await t.click(eventsEditPage.confirmDeleteButton);
 
-  // Wait for undo timer to be canceled
+  // Wait for view data to sync
   await t.wait(100);
 }

--- a/src/domain/events/edit/EventEdit.tsx
+++ b/src/domain/events/edit/EventEdit.tsx
@@ -30,7 +30,10 @@ const EventEditToolbar = (props: any) => {
   return (
     <Toolbar style={{ justifyContent: 'space-between' }} {...props}>
       <SaveButton />
-      <DeleteButton disabled={Boolean(props.record.occurrences.edges.length)} />
+      <DeleteButton
+        disabled={Boolean(props.record.occurrences.edges.length)}
+        undoable={props.undoable}
+      />
     </Toolbar>
   );
 };


### PR DESCRIPTION
## Description

The event editing view seems to have been configured to use the
confirmation pattern, but at some stage the custom edit toolbar has
severed the prop drilling between the form and the delete button. This
resulted in the default pattern, undo, being used instead.

Due to using a custom resource for the event list view, a resource that
contains both events and events groups, react-admin's soft delete
doesn't seem like it works. Instead of hiding the event as soon as
possible, the event is only hidden after the delte request is
completed. By using the confirmation pattern, as was apparently the
original intention, we are able to steer clear of the inefficient undo
logic.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-708](https://helsinkisolutionoffice.atlassian.net/browse/KK-708)

## How Has This Been Tested?

I've tested this manually. I've updated the browser test to remove special logic used for the undo delete pattern.

## Manual Testing Instructions for Reviewers

1. Go to event list
2. Create a new event
3. Select it
4. Go to edit view
5. Delete it
6. Expect for confirmation to be asked
7. Confirm
8. Expect to be redirected into list view
9. Expect event to disappear moderately quickly