### PR TITLE
KK-711 | Fix crashing occurrence view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Missing labels in venue and event detail views
 - Fix slow update od event and event group list by using confirmation pattern instead of undo pattern when deleting events
+- Occurrence view crash on reload
 
 ### Removed
 

--- a/src/domain/occurrences/Occurrence.ts
+++ b/src/domain/occurrences/Occurrence.ts
@@ -15,21 +15,33 @@ type OccurrenceType = {
 };
 
 class Occurrence {
-  occurrence: OccurrenceType;
+  occurrence?: OccurrenceType;
 
   constructor(occurrence: OccurrenceType) {
     this.occurrence = occurrence;
   }
 
   get time() {
+    if (!this.occurrence) {
+      return null;
+    }
+
     return toDateTimeString(new Date(this.occurrence.time));
   }
 
   get startTime() {
+    if (!this.occurrence) {
+      return null;
+    }
+
     return toTimeString(new Date(this.occurrence.time));
   }
 
   get endTime() {
+    if (!this.occurrence) {
+      return null;
+    }
+
     const duration = this.occurrence.event.duration; // minutes
 
     if (!duration) {
@@ -43,14 +55,26 @@ class Occurrence {
   }
 
   get duration() {
+    if (!this.occurrence) {
+      return null;
+    }
+
     return `${this.startTime} - ${this.endTime}`;
   }
 
   get occurrenceDateAndDuration() {
+    if (!this.occurrence) {
+      return null;
+    }
+
     return `${this.time} - ${this.endTime}`;
   }
 
   get title() {
+    if (!this.occurrence) {
+      return null;
+    }
+
     const translatedResourceName = i18nProvider.translate(
       'occurrences.show.title'
     );

--- a/src/domain/occurrences/OccurrenceShow.tsx
+++ b/src/domain/occurrences/OccurrenceShow.tsx
@@ -89,7 +89,7 @@ export const getBreadCrumbs = (record?: Record) =>
   new Occurrence(record as OccurrenceType).breadcrumbs;
 
 export const getTitle = (record?: Record) =>
-  new Occurrence(record as OccurrenceType).title;
+  new Occurrence(record as OccurrenceType).title || '';
 
 export const getChildFullName = (enrolmentEdge: EnrolmentEdge) =>
   `${enrolmentEdge.node?.child.firstName} ${enrolmentEdge.node?.child.lastName}`.trim();


### PR DESCRIPTION
## Description

The occurrence view would previously crash on reload.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-711](https://helsinkisolutionoffice.atlassian.net/browse/KK-711)

## How Has This Been Tested?

I've tested this manually.

## Manual Testing Instructions for Reviewers

1. Go to event list
2. Select an event with at least a occurrence
3. Go to occurrence tab
4. Select occurrence
5. Reload
6. Expect no error