### PR TITLE
KK-704 | Hide publish buttons when user does not have permissions to publish

### DIFF
--- a/src/api/generatedTypes/Event.ts
+++ b/src/api/generatedTypes/Event.ts
@@ -46,6 +46,14 @@ export interface Event_event_occurrences {
   edges: (Event_event_occurrences_edges | null)[];
 }
 
+export interface Event_event_project_myPermissions {
+  publish: boolean | null;
+}
+
+export interface Event_event_project {
+  myPermissions: Event_event_project_myPermissions | null;
+}
+
 export interface Event_event {
   /**
    * The ID of the object.
@@ -64,6 +72,7 @@ export interface Event_event {
   readyForEventGroupPublishing: boolean;
   eventGroup: Event_event_eventGroup | null;
   occurrences: Event_event_occurrences;
+  project: Event_event_project;
 }
 
 export interface Event {

--- a/src/api/generatedTypes/Event.ts
+++ b/src/api/generatedTypes/Event.ts
@@ -51,6 +51,10 @@ export interface Event_event_project_myPermissions {
 }
 
 export interface Event_event_project {
+  /**
+   * The ID of the object.
+   */
+  id: string;
   myPermissions: Event_event_project_myPermissions | null;
 }
 

--- a/src/api/generatedTypes/EventGroup.ts
+++ b/src/api/generatedTypes/EventGroup.ts
@@ -70,6 +70,13 @@ export interface EventGroup_eventGroup_events {
   edges: (EventGroup_eventGroup_events_edges | null)[];
 }
 
+export interface EventGroup_eventGroup_project {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+}
+
 export interface EventGroup_eventGroup {
   /**
    * The ID of the object.
@@ -79,6 +86,7 @@ export interface EventGroup_eventGroup {
   publishedAt: any | null;
   translations: EventGroup_eventGroup_translations[];
   events: EventGroup_eventGroup_events;
+  project: EventGroup_eventGroup_project;
 }
 
 export interface EventGroup {

--- a/src/api/generatedTypes/MyAdminProfile.ts
+++ b/src/api/generatedTypes/MyAdminProfile.ts
@@ -7,6 +7,10 @@
 // GraphQL query operation: MyAdminProfile
 // ====================================================
 
+export interface MyAdminProfile_myAdminProfile_projects_edges_node_myPermissions {
+  publish: boolean | null;
+}
+
 export interface MyAdminProfile_myAdminProfile_projects_edges_node {
   /**
    * The ID of the object.
@@ -14,6 +18,7 @@ export interface MyAdminProfile_myAdminProfile_projects_edges_node {
   id: string;
   year: number;
   name: string | null;
+  myPermissions: MyAdminProfile_myAdminProfile_projects_edges_node_myPermissions | null;
 }
 
 export interface MyAdminProfile_myAdminProfile_projects_edges {
@@ -35,7 +40,7 @@ export interface MyAdminProfile_myAdminProfile {
    * The ID of the object.
    */
   id: string;
-  projects: MyAdminProfile_myAdminProfile_projects;
+  projects: MyAdminProfile_myAdminProfile_projects | null;
 }
 
 export interface MyAdminProfile {

--- a/src/api/generatedTypes/Occurrence.ts
+++ b/src/api/generatedTypes/Occurrence.ts
@@ -86,7 +86,7 @@ export interface Occurrence_occurrence_enrolments_edges_node {
    */
   id: string;
   attended: boolean | null;
-  child: Occurrence_occurrence_enrolments_edges_node_child;
+  child: Occurrence_occurrence_enrolments_edges_node_child | null;
 }
 
 export interface Occurrence_occurrence_enrolments_edges {

--- a/src/api/generatedTypes/OccurrenceFragment.ts
+++ b/src/api/generatedTypes/OccurrenceFragment.ts
@@ -86,7 +86,7 @@ export interface OccurrenceFragment_enrolments_edges_node {
    */
   id: string;
   attended: boolean | null;
-  child: OccurrenceFragment_enrolments_edges_node_child;
+  child: OccurrenceFragment_enrolments_edges_node_child | null;
 }
 
 export interface OccurrenceFragment_enrolments_edges {

--- a/src/api/generatedTypes/Occurrences.ts
+++ b/src/api/generatedTypes/Occurrences.ts
@@ -86,7 +86,7 @@ export interface Occurrences_occurrences_edges_node_enrolments_edges_node {
    */
   id: string;
   attended: boolean | null;
-  child: Occurrences_occurrences_edges_node_enrolments_edges_node_child;
+  child: Occurrences_occurrences_edges_node_enrolments_edges_node_child | null;
 }
 
 export interface Occurrences_occurrences_edges_node_enrolments_edges {

--- a/src/api/generatedTypes/updateOccurrence.ts
+++ b/src/api/generatedTypes/updateOccurrence.ts
@@ -75,7 +75,7 @@ export interface updateOccurrence_updateOccurrence_occurrence_enrolments_edges_n
    */
   id: string;
   attended: boolean | null;
-  child: updateOccurrence_updateOccurrence_occurrence_enrolments_edges_node_child;
+  child: updateOccurrence_updateOccurrence_occurrence_enrolments_edges_node_child | null;
 }
 
 export interface updateOccurrence_updateOccurrence_occurrence_enrolments_edges {

--- a/src/domain/authentication/__tests__/authProvider.test.js
+++ b/src/domain/authentication/__tests__/authProvider.test.js
@@ -115,7 +115,13 @@ describe('authProvider', () => {
 
       jest.spyOn(authorizationService, 'getRole').mockReturnValue(role);
 
-      return expect(authProvider.getPermissions()).resolves.toEqual(role);
+      return expect(authProvider.getPermissions()).resolves
+        .toMatchInlineSnapshot(`
+                Object {
+                  "canPublishWithinProject": [Function],
+                  "role": "admin",
+                }
+              `);
     });
   });
 });

--- a/src/domain/authentication/authProvider.ts
+++ b/src/domain/authentication/authProvider.ts
@@ -4,6 +4,11 @@ import { history } from '../application/App';
 import authService from './authService';
 import authorizationService from './authorizationService';
 
+export type Permissions = {
+  role: null | 'admin' | 'none';
+  canPublishWithinProject: (projectId?: string) => boolean | null;
+};
+
 const authProvider: AuthProvider = {
   login: (next?: string) => authService.login(next),
   logout: async () => {
@@ -49,10 +54,13 @@ const authProvider: AuthProvider = {
 
     return Promise.reject();
   },
-  getPermissions: () => {
+  getPermissions: (): Promise<Permissions> => {
     const role = authorizationService.getRole();
 
-    return Promise.resolve(role);
+    return Promise.resolve({
+      role,
+      canPublishWithinProject: authorizationService.canPublishWithinProject,
+    });
   },
 };
 

--- a/src/domain/eventGroups/detail/EventGroupsDetail.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetail.tsx
@@ -40,7 +40,7 @@ const EventGroupsDetail = (props: ResourceComponentPropsWithId) => {
       pageTitleSource="name"
       reactAdminProps={{
         ...props,
-        actions: <EventGroupsDetailActions />,
+        actions: <EventGroupsDetailActions permissions={props.permissions} />,
       }}
       layout={KukkuuPageLayout}
       breadcrumbs={[

--- a/src/domain/eventGroups/detail/EventGroupsDetailActions.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetailActions.tsx
@@ -18,11 +18,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const EventGroupsDetailActions = ({ data, basePath }: any) => {
+const EventGroupsDetailActions = ({ data, basePath, permissions }: any) => {
   const t = useTranslate();
   const classes = useStyles();
 
   const isPublished = Boolean(data?.publishedAt);
+  const canPublish = permissions?.canPublishWithinProject(data?.project?.id);
 
   return (
     <TopToolbar className={classes.toolbar}>
@@ -31,7 +32,7 @@ const EventGroupsDetailActions = ({ data, basePath }: any) => {
         label={t('eventGroups.actions.addEvent.do')}
       />
       <EditButton basePath="/event-groups" record={data} />
-      {data && !isPublished && (
+      {data && !isPublished && canPublish && (
         <PublishEventGroupButton basePath={basePath} record={data} />
       )}
     </TopToolbar>

--- a/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
+++ b/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
@@ -31,8 +31,17 @@ describe('<EventGroupsDetailActions />', () => {
     expect(getByRole('button', { name: 'ra.action.edit' })).toBeTruthy();
   });
 
-  it('should render a publish button when there is data', () => {
-    const { getByRole } = getWrapper({ data: {} });
+  it('should render a publish button when there is data and the user has publish permissions', () => {
+    const { getByRole } = getWrapper({
+      data: {
+        project: {
+          id: '123',
+        },
+      },
+      permissions: {
+        canPublishWithinProject: () => true,
+      },
+    });
 
     expect(
       getByRole('button', { name: 'eventGroups.actions.publish.do' })

--- a/src/domain/eventGroups/queries/EvenGroupQueries.ts
+++ b/src/domain/eventGroups/queries/EvenGroupQueries.ts
@@ -41,6 +41,9 @@ export const eventGroupQuery = gql`
           }
         }
       }
+      project {
+        id
+      }
     }
   }
 

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -81,7 +81,10 @@ const EventShow = (props: ResourceComponentPropsWithId) => {
 
   return (
     <KukkuuDetailPage
-      reactAdminProps={{ ...props, actions: <EventShowActions /> }}
+      reactAdminProps={{
+        ...props,
+        actions: <EventShowActions permissions={props.permissions} />,
+      }}
       layout={KukkuuPageLayout}
       breadcrumbs={(record?: Record) => getCrumbs(record)}
       pageTitleSource="name"

--- a/src/domain/events/detail/EventShowActions.tsx
+++ b/src/domain/events/detail/EventShowActions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { EditButton, TopToolbar } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 
+import { Permissions } from '../../authentication/authProvider';
 import { AdminEvent } from '../types/EventTypes';
 import EventReadyToggle from './EventReadyToggle';
 import EventPublishButton from './EventPublishButton';
@@ -18,17 +19,20 @@ const useStyles = makeStyles(() => ({
 type Props = {
   basePath?: string;
   data?: AdminEvent;
+  permissions?: Permissions;
 };
 
-const EventShowActions = ({ basePath, data }: Props) => {
+const EventShowActions = ({ basePath, data, permissions }: Props) => {
   const hasEventGroup = Boolean(data?.eventGroup);
   const isPublished = Boolean(data?.publishedAt);
   const classes = useStyles();
 
+  const canPublish = permissions?.canPublishWithinProject(data?.project.id);
+
   return (
     <TopToolbar>
       <EditButton basePath={basePath} record={data} />
-      {data && !hasEventGroup && !isPublished && (
+      {data && !hasEventGroup && !isPublished && canPublish && (
         <EventPublishButton basePath={basePath} record={data} />
       )}
       {data && hasEventGroup && !isPublished && (

--- a/src/domain/events/detail/__tests__/EventShowActions.test.jsx
+++ b/src/domain/events/detail/__tests__/EventShowActions.test.jsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { TestContext } from 'react-admin';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@material-ui/styles';
 import { createMuiTheme } from '@material-ui/core';
 
+import authorizationService from '../../../authentication/authorizationService';
 import EventShowActions from '../EventShowActions';
 
 const defaultProps = {
-  data: {},
+  data: {
+    project: {
+      id: '123',
+    },
+  },
 };
 const getWrapper = (props) =>
   render(
@@ -25,12 +30,20 @@ describe('<EventShowActions />', () => {
     expect(getByRole('button', { name: 'ra.action.edit' })).toBeTruthy();
   });
 
-  it('should render event publish button', () => {
-    const { getByRole } = getWrapper();
+  describe('when the user has publish permissions', () => {
+    it('should render event publish button', async () => {
+      const { getByRole } = getWrapper({
+        permissions: {
+          canPublishWithinProject: () => true,
+        },
+      });
 
-    expect(
-      getByRole('button', { name: 'events.show.publish.button.label' })
-    ).toBeTruthy();
+      await waitFor(() =>
+        expect(
+          getByRole('button', { name: 'events.show.publish.button.label' })
+        ).toBeTruthy()
+      );
+    });
   });
 
   describe('when the event has an event group', () => {

--- a/src/domain/events/queries/EventQueries.ts
+++ b/src/domain/events/queries/EventQueries.ts
@@ -61,6 +61,12 @@ export const eventQuery = gql`
           }
         }
       }
+      project {
+        id
+        myPermissions {
+          publish
+        }
+      }
     }
   }
 `;

--- a/src/domain/events/types/EventTypes.ts
+++ b/src/domain/events/types/EventTypes.ts
@@ -12,4 +12,7 @@ export interface AdminEvent {
   translations: AdminUITranslation<Omit<ApiEventTranslation, 'languageCode'>>;
   eventGroup?: EventGroup;
   readyForEventGroupPublishing: boolean;
+  project: {
+    id: string;
+  };
 }

--- a/src/domain/occurrences/OccurrenceShow.tsx
+++ b/src/domain/occurrences/OccurrenceShow.tsx
@@ -70,7 +70,7 @@ export const withGuardian = (
   hasRecord: (guardian: GuardianType) => string,
   otherwise: () => any
 ) => (enrollmentRecord: EnrolmentEdge) => {
-  const guardian = enrollmentRecord.node?.child.guardians.edges[0]?.node;
+  const guardian = enrollmentRecord.node?.child?.guardians.edges[0]?.node;
 
   if (guardian) {
     return hasRecord(guardian as GuardianType);
@@ -92,7 +92,7 @@ export const getTitle = (record?: Record) =>
   new Occurrence(record as OccurrenceType).title || '';
 
 export const getChildFullName = (enrolmentEdge: EnrolmentEdge) =>
-  `${enrolmentEdge.node?.child.firstName} ${enrolmentEdge.node?.child.lastName}`.trim();
+  `${enrolmentEdge.node?.child?.firstName} ${enrolmentEdge.node?.child?.lastName}`.trim();
 
 const OccurrenceShow = (props: any) => {
   const locale = useLocale();

--- a/src/domain/profile/queries.ts
+++ b/src/domain/profile/queries.ts
@@ -10,6 +10,9 @@ export const myAdminProfileQuery = gql`
             id
             year
             name
+            myPermissions {
+              publish
+            }
           }
         }
       }


### PR DESCRIPTION
## Description

Adjusts the authorizatoin service so that it can be used to check user's permissions on a project per project basis.

Adds checks when rendering event and event group publish buttons which avoids rendering them when the user does not have permission to publish.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-704](https://helsinkisolutionoffice.atlassian.net/browse/KK-704)

## How Has This Been Tested?

I've adjusted the existing tests to cover the changed and new behaviour.

## Manual Testing Instructions for Reviewers

As a user with publish level permissions to a project

1. Navigate to an unpublished event that's not within an event group
2. Expect to see publish button
3. Navigate to an unpublished event group
4. Expect to see publish button

As a user without publish level permissions to a project

1. Navigate to an unpublished event that's not within an event group
2. Expect to not see a publish button
3. Navigate to an unpublished event group
4. Expect to not see publish button