### PR TITLE
KK-717 | Fix event details view crashing after event creation

### DIFF
--- a/src/domain/events/detail/EventShowActions.tsx
+++ b/src/domain/events/detail/EventShowActions.tsx
@@ -27,7 +27,7 @@ const EventShowActions = ({ basePath, data, permissions }: Props) => {
   const isPublished = Boolean(data?.publishedAt);
   const classes = useStyles();
 
-  const canPublish = permissions?.canPublishWithinProject(data?.project.id);
+  const canPublish = permissions?.canPublishWithinProject(data?.project?.id);
 
   return (
     <TopToolbar>


### PR DESCRIPTION
## Description

After #148 the event details view started to crash after event creation, because the project was accessed before it was available.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-717](https://helsinkisolutionoffice.atlassian.net/browse/KK-717)

## Manual Testing Instructions for Reviewers

1. Create event
2. Expect creation to not lead to an error