### PR TITLE
KK-710 | Fix crash in venue field after re-entering edit view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Missing labels in venue and event detail views
 - Fix slow update od event and event group list by using confirmation pattern instead of undo pattern when deleting events
 - Occurrence view crash on reload
+- Crashing venue editing field when re-entering after a successful edit
 
 ### Removed
 

--- a/src/domain/venues/VenueEdit.tsx
+++ b/src/domain/venues/VenueEdit.tsx
@@ -21,7 +21,7 @@ const VenueEditToolbar = (props: any) => {
     <Toolbar style={{ justifyContent: 'space-between' }} {...props}>
       <SaveButton />
       <DeleteButton
-        disabled={Boolean(props.record.occurrences.pageInfo.startCursor)}
+        disabled={Boolean(props.record.occurrences?.pageInfo?.startCursor)}
       />
     </Toolbar>
   );


### PR DESCRIPTION
## Description

Re-entering a venue's edit view after a successful edit would cause a crash.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-710](https://helsinkisolutionoffice.atlassian.net/browse/KK-710)

## Manual Testing Instructions for Reviewers

Reproduction

1. Select venue
2. Change field
3. Edit
4. Expect to be redirected to venue details
5. Re-enter edit view
6. Error