### PR TITLE
KK-714 | Change translation sheet to one owned by executive office

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Application title
 - Distinct test environment from production environment
+- Translation sheet to one controlled by the executive office
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "eject": "react-scripts eject",
     "lint": "eslint --ext js,ts,tsx src",
     "graphql-types": "apollo client:codegen --target=typescript --no-addTypename --outputFlat src/api/generatedTypes",
-    "update-translations": "fetch-translations 1hmdfJ-iVIqsD4AN2vx2YMMM2BQs-en1xxsX2Vu5_7vY -l fi,en -o ./src/common/translation",
+    "update-translations": "fetch-translations 1lixUcdpxyEy5wVsI8b74_eoIvAjvPgNTcO0Ngy-WJ-c -l fi,en -o ./src/common/translation",
     "test:browser": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/ --live",
     "test:browser:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" browser-tests/ -s takeOnFails=true --lang=fi-FI"
   },


### PR DESCRIPTION
## Description

Changes the translation sheet to one that is managed under the XO's account.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-714](https://helsinkisolutionoffice.atlassian.net/browse/KK-714)

## How Has This Been Tested?

I changed the sheet id and rant he translation script. The script worked and did not cause any changes = I'm happy.

## Manual Testing Instructions for Reviewers

You can try running the script locally. Hit me up if you want to edit the sheet.