### PR TITLE
KK-725 | Hide event creation button when not supported in project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Hide create event button when project does not allow loose events
+
 ## [1.5.4] - 2021-02-11
 
 ### Fixed
+
 - [#154](https://github.com/City-of-Helsinki/kukkuu-admin/pull/154) Production build API URL
 
 ## [1.5.3] - 2021-02-10

--- a/src/api/generatedTypes/Project.ts
+++ b/src/api/generatedTypes/Project.ts
@@ -20,6 +20,10 @@ export interface Project_project {
    */
   id: string;
   year: number;
+  /**
+   * Whether it is allowed to create events outside event groups.
+   */
+  singleEventsAllowed: boolean;
   translations: Project_project_translations[];
 }
 

--- a/src/domain/dashboard/queries.ts
+++ b/src/domain/dashboard/queries.ts
@@ -5,6 +5,7 @@ export const projectQuery = gql`
     project(id: $id) {
       id
       year
+      singleEventsAllowed
       translations {
         languageCode
         name

--- a/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
+++ b/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
@@ -8,6 +8,7 @@ import {
   TopToolbar,
   CreateButton,
   ReactAdminComponentProps,
+  useQuery,
 } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 
@@ -21,6 +22,7 @@ import { toDateTimeString } from '../../../common/utils';
 import PublishedField from '../../../common/components/publishedField/PublishedField';
 import KukkuuListPage from '../../application/layout/kukkuuListPage/KukkuuListPage';
 import { countCapacity, countOccurrences } from '../../events/utils';
+import ProfileService from '../../profile/profileService';
 
 const useEventsAndEventGroupsListToolbarStyles = makeStyles((theme) => ({
   toolbar: {
@@ -34,6 +36,13 @@ const useEventsAndEventGroupsListToolbarStyles = makeStyles((theme) => ({
 const EventsAndEventGroupsListToolbar = ({ data }: any) => {
   const t = useTranslate();
   const classes = useEventsAndEventGroupsListToolbarStyles();
+  const { data: profileData } = useQuery({
+    type: 'getOne',
+    resource: 'projects',
+    payload: {
+      id: ProfileService.projectId,
+    },
+  });
 
   return (
     <TopToolbar className={classes.toolbar}>
@@ -43,7 +52,7 @@ const EventsAndEventGroupsListToolbar = ({ data }: any) => {
           label={t('eventGroups.actions.create.do')}
         />
       )}
-      {data && (
+      {data && profileData?.singleEventsAllowed && (
         <CreateButton basePath="events" label={t('events.actions.create')} />
       )}
     </TopToolbar>


### PR DESCRIPTION
## Description

Hides event creation button in projects which have been configured to not allow loose events.

Uses react-admin's `useQuery` to fetch project data within the event and event group list toolbar component.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-725](https://helsinkisolutionoffice.atlassian.net/browse/KK-725)

## How Has This Been Tested?

I've tested this by hand.

## Manual Testing Instructions for Reviewers

When a project's `singleEventsAllowed` configuration is toggled as false, the user should not be able to create events outside of event groups.