### PR TITLE
KK-728 | Hide event group create and edit buttons when user does not have permissions for CRUD operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Hide create event button when project does not allow loose events
+- Hide event group create and edit button when the user is not authorized with CRUD permissions
 
 ## [1.5.4] - 2021-02-11
 

--- a/src/api/generatedTypes/MyAdminProfile.ts
+++ b/src/api/generatedTypes/MyAdminProfile.ts
@@ -9,6 +9,7 @@
 
 export interface MyAdminProfile_myAdminProfile_projects_edges_node_myPermissions {
   publish: boolean | null;
+  manageEventGroups: boolean | null;
 }
 
 export interface MyAdminProfile_myAdminProfile_projects_edges_node {

--- a/src/domain/authentication/__tests__/authProvider.test.js
+++ b/src/domain/authentication/__tests__/authProvider.test.js
@@ -118,6 +118,7 @@ describe('authProvider', () => {
       return expect(authProvider.getPermissions()).resolves
         .toMatchInlineSnapshot(`
                 Object {
+                  "canManageEventGroupsWithinProject": [Function],
                   "canPublishWithinProject": [Function],
                   "role": "admin",
                 }

--- a/src/domain/authentication/__tests__/authProvider.test.js
+++ b/src/domain/authentication/__tests__/authProvider.test.js
@@ -1,5 +1,5 @@
 import { history } from '../../application/App';
-import profileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 import authProvider from '../authProvider';
 import authService from '../authService';
 import authorizationService from '../authorizationService';
@@ -11,7 +11,7 @@ describe('authProvider', () => {
 
   beforeEach(() => {
     jest.restoreAllMocks();
-    projectIdSpy = jest.spyOn(profileService, 'projectId', 'get');
+    projectIdSpy = jest.spyOn(projectService, 'projectId', 'get');
   });
 
   describe('login', () => {

--- a/src/domain/authentication/__tests__/authorizationService.test.js
+++ b/src/domain/authentication/__tests__/authorizationService.test.js
@@ -1,5 +1,5 @@
 import dataProvider from '../../../api/dataProvider';
-import profileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 import authorizationService, { PERMISSIONS } from '../authorizationService';
 
 const setPermissions = (permissions = 'admin') => {
@@ -12,7 +12,7 @@ const setPermissions = (permissions = 'admin') => {
 
 describe('authorizationService', () => {
   let dataProviderSpy;
-  let profileServiceSpy;
+  let projectServiceSpy;
 
   beforeEach(() => {
     dataProviderSpy = jest
@@ -33,8 +33,8 @@ describe('authorizationService', () => {
           },
         },
       });
-    profileServiceSpy = jest
-      .spyOn(profileService, 'setDefaultProjectId')
+    projectServiceSpy = jest
+      .spyOn(projectService, 'setDefaultProjectId')
       .mockReturnValue();
   });
 
@@ -81,12 +81,12 @@ describe('authorizationService', () => {
       );
     });
 
-    it('should call profileService.profileServiceSpy', async () => {
+    it('should call projectService.projectServiceSpy', async () => {
       expect.assertions(1);
 
       await authorizationService.fetchRole();
 
-      expect(profileServiceSpy).toHaveBeenCalledTimes(1);
+      expect(projectServiceSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should set project permissions', async () => {

--- a/src/domain/authentication/authProvider.ts
+++ b/src/domain/authentication/authProvider.ts
@@ -60,6 +60,8 @@ const authProvider: AuthProvider = {
     return Promise.resolve({
       role,
       canPublishWithinProject: authorizationService.canPublishWithinProject,
+      canManageEventGroupsWithinProject:
+        authorizationService.canManageEventGroupsWithinProject,
     });
   },
 };

--- a/src/domain/authentication/authService.ts
+++ b/src/domain/authentication/authService.ts
@@ -8,7 +8,7 @@ import {
 import axios from 'axios';
 import * as Sentry from '@sentry/browser';
 
-import profileService from '../profile/profileService';
+import projectService from '../projects/projectService';
 import authorizationService from './authorizationService';
 
 const origin = window.location.origin;
@@ -117,7 +117,7 @@ export class AuthService {
 
   public async logout(): Promise<void> {
     localStorage.removeItem(API_TOKEN);
-    profileService.clear();
+    projectService.clear();
     this.userManager.clearStaleState();
     authorizationService.clear();
     await this.userManager.signoutRedirect();

--- a/src/domain/authentication/authorizationService.ts
+++ b/src/domain/authentication/authorizationService.ts
@@ -52,6 +52,9 @@ export class AuthorizationService {
     this.getRole = this.getRole.bind(this);
     this.clear = this.clear.bind(this);
     this.canPublishWithinProject = this.canPublishWithinProject.bind(this);
+    this.canManageEventGroupsWithinProject = this.canManageEventGroupsWithinProject.bind(
+      this
+    );
   }
 
   private get permissionStorage(): null | PermissionStorage {
@@ -98,6 +101,16 @@ export class AuthorizationService {
     const projectPermissions = this.getProjectPermissions(projectId);
 
     return projectPermissions.includes('publish');
+  }
+
+  canManageEventGroupsWithinProject(projectId?: string) {
+    if (!projectId) {
+      return null;
+    }
+
+    const projectPermissions = this.getProjectPermissions(projectId);
+
+    return projectPermissions.includes('manageEventGroups');
   }
 
   private getProjectPermissions(projectId: string) {

--- a/src/domain/authentication/authorizationService.ts
+++ b/src/domain/authentication/authorizationService.ts
@@ -4,7 +4,7 @@ import {
 } from '../../api/generatedTypes/MyAdminProfile';
 import RelayList from '../../api/relayList';
 import dataProvider from '../../api/dataProvider';
-import projectService from '../profile/profileService';
+import projectService from '../projects/projectService';
 
 export const PERMISSIONS = 'permissions';
 

--- a/src/domain/children/api/ChildApi.ts
+++ b/src/domain/children/api/ChildApi.ts
@@ -9,13 +9,13 @@ import {
 } from '../../../api/utils/apiUtils';
 import { childrenQuery, childQuery } from '../queries/ChildQueries';
 import { Child as ApiChild } from '../../../api/generatedTypes/Child';
-import profileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 
 const getChildren: MethodHandler = async (params: MethodHandlerParams) => {
   const response: ApolloQueryResult<Children> = await queryHandler({
     query: childrenQuery,
     variables: {
-      projectId: profileService.projectId,
+      projectId: projectService.projectId,
       occurrenceId: params.id,
       limit: params.pagination.limit,
       offset: params.pagination.offset,

--- a/src/domain/dashboard/Dashboard.tsx
+++ b/src/domain/dashboard/Dashboard.tsx
@@ -12,7 +12,7 @@ import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
 import * as Sentry from '@sentry/browser';
 
-import profileService from '../profile/profileService';
+import projectService from '../projects/projectService';
 import { getTranslatedField } from '../../common/translation/TranslationUtils';
 
 export default () => {
@@ -26,7 +26,7 @@ export default () => {
     {
       type: 'getOne',
       resource: 'projects',
-      payload: { id: profileService.projectId },
+      payload: { id: projectService.projectId },
     },
     {
       onFailure: (error: Error) => {

--- a/src/domain/eventGroups/api/eventGroupsApi.ts
+++ b/src/domain/eventGroups/api/eventGroupsApi.ts
@@ -7,7 +7,7 @@ import {
   mutationHandler,
 } from '../../../api/utils/apiUtils';
 import RelayList from '../../../api/relayList';
-import profileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 import { eventGroupQuery } from '../queries/EvenGroupQueries';
 import {
   addEventGroupMutation,
@@ -39,7 +39,7 @@ async function addEventGroup(params: MethodHandlerParams) {
     variables: {
       input: {
         ...data,
-        projectId: profileService.projectId,
+        projectId: projectService.projectId,
       },
     },
   });
@@ -52,7 +52,7 @@ async function updateEventGroup(params: MethodHandlerParams) {
   const input = {
     id,
     translations,
-    projectId: profileService.projectId,
+    projectId: projectService.projectId,
   };
   const cleanedInput = mapLocalDataToApiData(input);
   const response = await mutationHandler({

--- a/src/domain/eventGroups/detail/EventGroupsDetailActions.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetailActions.tsx
@@ -24,6 +24,9 @@ const EventGroupsDetailActions = ({ data, basePath, permissions }: any) => {
 
   const isPublished = Boolean(data?.publishedAt);
   const canPublish = permissions?.canPublishWithinProject(data?.project?.id);
+  const canManageEventGroups = permissions?.canManageEventGroupsWithinProject(
+    data?.project?.id
+  );
 
   return (
     <TopToolbar className={classes.toolbar}>
@@ -31,7 +34,9 @@ const EventGroupsDetailActions = ({ data, basePath, permissions }: any) => {
         to={`/events/create?eventGroupId=${data?.id}`}
         label={t('eventGroups.actions.addEvent.do')}
       />
-      <EditButton basePath="/event-groups" record={data} />
+      {canManageEventGroups && (
+        <EditButton basePath="/event-groups" record={data} />
+      )}
       {data && !isPublished && canPublish && (
         <PublishEventGroupButton basePath={basePath} record={data} />
       )}

--- a/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
+++ b/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
@@ -26,7 +26,12 @@ describe('<EventGroupsDetailActions />', () => {
   });
 
   it('should show an edit button', () => {
-    const { getByRole } = getWrapper();
+    const { getByRole } = getWrapper({
+      permissions: {
+        canPublishWithinProject: () => true,
+        canManageEventGroupsWithinProject: () => true,
+      },
+    });
 
     expect(getByRole('button', { name: 'ra.action.edit' })).toBeTruthy();
   });
@@ -40,6 +45,7 @@ describe('<EventGroupsDetailActions />', () => {
       },
       permissions: {
         canPublishWithinProject: () => true,
+        canManageEventGroupsWithinProject: () => true,
       },
     });
 

--- a/src/domain/events/api/EventApi.ts
+++ b/src/domain/events/api/EventApi.ts
@@ -17,12 +17,12 @@ import {
   updateEventMutation,
   deleteEventMutation,
 } from '../mutations/EventMutations';
-import profileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 
 const getEvents: MethodHandler = async (params: MethodHandlerParams) => {
   const response = await queryHandler({
     query: eventsQuery,
-    variables: { projectId: profileService.projectId },
+    variables: { projectId: projectService.projectId },
   });
   return handleApiConnection(response.data.events);
 };
@@ -37,7 +37,7 @@ const getEvent: MethodHandler = async (params: MethodHandlerParams) => {
 
 const addEvent: MethodHandler = async (params: MethodHandlerParams) => {
   const data = mapLocalDataToApiData(params.data);
-  data['projectId'] = profileService.projectId;
+  data['projectId'] = projectService.projectId;
   if (params.data.image) {
     data.image = params.data.image.rawFile;
   }

--- a/src/domain/eventsAndEventGroups/api/eventsAndEventGroupsApi.ts
+++ b/src/domain/eventsAndEventGroups/api/eventsAndEventGroupsApi.ts
@@ -1,12 +1,12 @@
 import { MethodHandlerParams } from '../../../api/types';
 import { queryHandler, handleApiConnection } from '../../../api/utils/apiUtils';
-import profileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 import { eventsAndEventGroupsQuery } from '../queries/EventsAndEventGroupsQueries';
 
 async function getEventsAndEventGroups(params: MethodHandlerParams) {
   const response = await queryHandler({
     query: eventsAndEventGroupsQuery,
-    variables: { projectId: profileService.projectId },
+    variables: { projectId: projectService.projectId },
   });
 
   return handleApiConnection(response.data.eventsAndEventGroups);

--- a/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
+++ b/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
@@ -22,7 +22,7 @@ import { toDateTimeString } from '../../../common/utils';
 import PublishedField from '../../../common/components/publishedField/PublishedField';
 import KukkuuListPage from '../../application/layout/kukkuuListPage/KukkuuListPage';
 import { countCapacity, countOccurrences } from '../../events/utils';
-import ProfileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 
 const useEventsAndEventGroupsListToolbarStyles = makeStyles((theme) => ({
   toolbar: {
@@ -40,12 +40,12 @@ const EventsAndEventGroupsListToolbar = ({ data, permissions }: any) => {
     type: 'getOne',
     resource: 'projects',
     payload: {
-      id: ProfileService.projectId,
+      id: projectService.projectId,
     },
   });
 
   const canManageEventGroups = permissions?.canManageEventGroupsWithinProject(
-    ProfileService.projectId
+    projectService.projectId
   );
 
   return (

--- a/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
+++ b/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
@@ -33,7 +33,7 @@ const useEventsAndEventGroupsListToolbarStyles = makeStyles((theme) => ({
   },
 }));
 
-const EventsAndEventGroupsListToolbar = ({ data }: any) => {
+const EventsAndEventGroupsListToolbar = ({ data, permissions }: any) => {
   const t = useTranslate();
   const classes = useEventsAndEventGroupsListToolbarStyles();
   const { data: projectData } = useQuery({
@@ -44,9 +44,13 @@ const EventsAndEventGroupsListToolbar = ({ data }: any) => {
     },
   });
 
+  const canManageEventGroups = permissions?.canManageEventGroupsWithinProject(
+    ProfileService.projectId
+  );
+
   return (
     <TopToolbar className={classes.toolbar}>
-      {data && (
+      {data && canManageEventGroups && (
         <CreateButton
           basePath="event-groups"
           label={t('eventGroups.actions.create.do')}
@@ -112,7 +116,9 @@ const EventsAndEventGroupsList = (props: ReactAdminComponentProps) => {
       pageTitle={translate('events.list.title')}
       reactAdminProps={{
         ...props,
-        actions: <EventsAndEventGroupsListToolbar />,
+        actions: (
+          <EventsAndEventGroupsListToolbar permissions={props.permissions} />
+        ),
       }}
       datagridProps={{
         rowClick: handleRowClick,

--- a/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
+++ b/src/domain/eventsAndEventGroups/list/EventsAndEventGroupsList.tsx
@@ -36,7 +36,7 @@ const useEventsAndEventGroupsListToolbarStyles = makeStyles((theme) => ({
 const EventsAndEventGroupsListToolbar = ({ data }: any) => {
   const t = useTranslate();
   const classes = useEventsAndEventGroupsListToolbarStyles();
-  const { data: profileData } = useQuery({
+  const { data: projectData } = useQuery({
     type: 'getOne',
     resource: 'projects',
     payload: {
@@ -52,7 +52,7 @@ const EventsAndEventGroupsListToolbar = ({ data }: any) => {
           label={t('eventGroups.actions.create.do')}
         />
       )}
-      {data && profileData?.singleEventsAllowed && (
+      {data && projectData?.singleEventsAllowed && (
         <CreateButton basePath="events" label={t('events.actions.create')} />
       )}
     </TopToolbar>

--- a/src/domain/messages/api/messagesApi.ts
+++ b/src/domain/messages/api/messagesApi.ts
@@ -15,14 +15,14 @@ import {
   updateMessageMutation,
   deleteMessageMutation,
 } from '../mutations/MessageMutations';
-import profileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 
 async function getMessages(
   params: MethodHandlerParams
 ): Promise<MethodHandlerResponse | null> {
   const response = await queryHandler({
     query: messagesQuery,
-    variables: { projectId: profileService.projectId },
+    variables: { projectId: projectService.projectId },
   });
 
   return handleApiConnection(response.data.messages);
@@ -85,7 +85,7 @@ async function addMessage(
     variables: {
       input: {
         ...data,
-        projectId: profileService.projectId,
+        projectId: projectService.projectId,
       },
     },
   });

--- a/src/domain/occurrences/api/OccurrenceApi.ts
+++ b/src/domain/occurrences/api/OccurrenceApi.ts
@@ -21,7 +21,7 @@ import {
   deleteOccurrenceMutation,
   setEnrolmentAttendanceMutation,
 } from '../mutations/OccurrenceMutations';
-import profileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 
 moment.tz.setDefault('Europe/Helsinki');
 
@@ -29,7 +29,7 @@ const getOccurrences: MethodHandler = async (params: MethodHandlerParams) => {
   const response: ApolloQueryResult<ApiOccurrences> = await queryHandler({
     query: occurrencesQuery,
     variables: {
-      projectId: profileService.projectId,
+      projectId: projectService.projectId,
       ...params.filter,
     },
   });
@@ -114,7 +114,7 @@ const setEnrolmentAttendance = async (
 const getOccurrencesManyReference = async (params: MethodHandlerParams) => {
   const response: ApolloQueryResult<ApiOccurrences> = await queryHandler({
     query: occurrencesQuery,
-    variables: { projectId: profileService.projectId, eventId: params.id },
+    variables: { projectId: projectService.projectId, eventId: params.id },
   });
   return handleApiConnection(response.data.occurrences);
 };

--- a/src/domain/profile/ProfileProjectDropdown.tsx
+++ b/src/domain/profile/ProfileProjectDropdown.tsx
@@ -9,7 +9,7 @@ import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 // eslint-disable-next-line max-len
 import { MyAdminProfile_myAdminProfile_projects_edges_node as ProjectNode } from '../../api/generatedTypes/MyAdminProfile';
 import RelayList from '../../api/relayList';
-import profileService from './profileService';
+import projectService from '../projects/projectService';
 
 const ProjectList = RelayList<ProjectNode>();
 
@@ -37,7 +37,7 @@ const ProfileProjectDropdown = () => {
   const handleMenuItemClick = (event: any) => {
     const value = event.target.dataset.value;
 
-    profileService.projectId = value as string;
+    projectService.projectId = value as string;
 
     refresh();
     handleClose();
@@ -62,7 +62,7 @@ const ProfileProjectDropdown = () => {
   }
 
   const selectedProject = projects.find(
-    (project) => project.id === profileService.projectId
+    (project) => project.id === projectService.projectId
   ) as ProjectNode;
 
   if (!selectedProject) {

--- a/src/domain/profile/__tests__/ProfileProjectDropdown.test.jsx
+++ b/src/domain/profile/__tests__/ProfileProjectDropdown.test.jsx
@@ -4,7 +4,7 @@ import { render, fireEvent } from '@testing-library/react';
 import * as DataProvider from 'ra-core/lib/dataProvider';
 import * as SideEffect from 'ra-core/lib/sideEffect';
 
-import profileService from '../profileService';
+import projectService from '../../projects/projectService';
 import ProfileProjectDropdown from '../ProfileProjectDropdown';
 
 const getWrapper = () =>
@@ -37,7 +37,7 @@ const getProjects = (projects) => ({
 
 describe('<ProfileProjectDropdown />', () => {
   beforeEach(() => {
-    jest.spyOn(profileService, 'projectId', 'get').mockReturnValue('1');
+    jest.spyOn(projectService, 'projectId', 'get').mockReturnValue('1');
   });
 
   it('should render null when loading', () => {
@@ -71,7 +71,7 @@ describe('<ProfileProjectDropdown />', () => {
   });
 
   it('should render null when there is not selected project', () => {
-    jest.spyOn(profileService, 'projectId', 'get').mockReturnValue(null);
+    jest.spyOn(projectService, 'projectId', 'get').mockReturnValue(null);
     jest
       .spyOn(DataProvider, 'useQueryWithStore')
       .mockReturnValue({ loading: false, data: getProjects(projects) });
@@ -97,7 +97,7 @@ describe('<ProfileProjectDropdown />', () => {
       loading: false,
       data: getProjects(projects),
     });
-    const projectServiceSpy = jest.spyOn(profileService, 'projectId', 'set');
+    const projectServiceSpy = jest.spyOn(projectService, 'projectId', 'set');
     const mockRefresh = jest.fn();
     const refreshSpy = jest
       .spyOn(SideEffect, 'useRefresh')

--- a/src/domain/profile/queries.ts
+++ b/src/domain/profile/queries.ts
@@ -12,6 +12,7 @@ export const myAdminProfileQuery = gql`
             name
             myPermissions {
               publish
+              manageEventGroups
             }
           }
         }

--- a/src/domain/projects/__tests__/profileService.test.js
+++ b/src/domain/projects/__tests__/profileService.test.js
@@ -1,14 +1,14 @@
-import profileService from '../profileService';
+import projectService from '../projectService';
 
-describe('profileService', () => {
+describe('projectService', () => {
   describe('projectId', () => {
     it('should allow project id to be set and got', () => {
-      expect(profileService.projectId).toEqual(null);
+      expect(projectService.projectId).toEqual(null);
 
-      profileService.projectId = '1';
+      projectService.projectId = '1';
 
       expect(localStorage.setItem).toHaveBeenCalledTimes(1);
-      expect(profileService.projectId).toEqual('1');
+      expect(projectService.projectId).toEqual('1');
       expect(localStorage.getItem).toHaveBeenCalledTimes(2);
     });
   });
@@ -26,25 +26,25 @@ describe('profileService', () => {
         },
       ];
 
-      profileService.setDefaultProjectId(projects);
+      projectService.setDefaultProjectId(projects);
 
-      expect(profileService.projectId).toEqual('1');
+      expect(projectService.projectId).toEqual('1');
     });
   });
 
   describe('clear', () => {
     it('should clear localStorage of data from this service', () => {
-      profileService.clear();
+      projectService.clear();
 
       expect(localStorage.removeItem).toHaveBeenCalledTimes(1);
     });
 
     it('should clear project id', () => {
-      profileService.projectId = '1';
+      projectService.projectId = '1';
 
-      profileService.clear();
+      projectService.clear();
 
-      expect(profileService.projectId).toEqual(null);
+      expect(projectService.projectId).toEqual(null);
     });
   });
 });

--- a/src/domain/projects/projectService.ts
+++ b/src/domain/projects/projectService.ts
@@ -3,7 +3,7 @@ import { MyAdminProfile_myAdminProfile_projects_edges_node as ProjectNode } from
 
 const PROJECT_ID_KEY = 'projectId';
 
-class ProfileService {
+class ProjectService {
   set projectId(id: string | null) {
     if (id) {
       localStorage.setItem(PROJECT_ID_KEY, id);
@@ -29,4 +29,4 @@ class ProfileService {
   }
 }
 
-export default new ProfileService();
+export default new ProjectService();

--- a/src/domain/venues/api/VenueApi.ts
+++ b/src/domain/venues/api/VenueApi.ts
@@ -17,7 +17,7 @@ import {
   handleApiConnection,
 } from '../../../api/utils/apiUtils';
 import { AdminVenue } from '../types/VenueTypes';
-import profileService from '../../profile/profileService';
+import projectService from '../../projects/projectService';
 
 /**
  * Get list of venues
@@ -25,7 +25,7 @@ import profileService from '../../profile/profileService';
 const getVenues: MethodHandler = async (params: MethodHandlerParams) => {
   const response: ApolloQueryResult<ApiVenues> = await queryHandler({
     query: venuesQuery,
-    variables: { projectId: profileService.projectId },
+    variables: { projectId: projectService.projectId },
   });
   return handleApiConnection(response.data.venues);
 };
@@ -40,7 +40,7 @@ const getVenue: MethodHandler = async (params: MethodHandlerParams) => {
 
 const addVenue: MethodHandler = async (params: MethodHandlerParams) => {
   const data = mapLocalDataToApiData(params.data as AdminVenue);
-  data['projectId'] = profileService.projectId;
+  data['projectId'] = projectService.projectId;
   const response = await mutationHandler({
     mutation: addVenueMutation,
     variables: { input: data },


### PR DESCRIPTION
## Description

Hides the create and edit buttons for users who do not have crud permissions for event groups within a project.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-728](https://helsinkisolutionoffice.atlassian.net/browse/KK-728)

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Ensure that users are not able to access the CRUD buttons for event groups (create, edit, delete) when they do not have the `Can create, update and delete event groups` permission within the project the event group belongs to.