### PR TITLE
KK-669 | Fix null recipient count labeled as '?'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Hide create event button when project does not allow loose events
 - Hide event group create and edit button when the user is not authorized with CRUD permissions
 
+### Fixed
+
+- Zero recipient count being shown as a question mark
+
 ## [1.5.4] - 2021-02-11
 
 ### Fixed

--- a/src/domain/messages/fields/MessageRecipientCountField.tsx
+++ b/src/domain/messages/fields/MessageRecipientCountField.tsx
@@ -17,7 +17,7 @@ const MessageRecipientCountField = ({ record }: any) => {
   const classes = useStyles();
 
   const sentAt = record?.sentAt;
-  const recipientCount = record?.recipientCount || '?';
+  const recipientCount = record?.recipientCount;
 
   // If message is sent, the recipient count is shown under the message
   // title and we don't need to show it in the message body.


### PR DESCRIPTION
## Description

Removes the default value that was used for 0 recipient counts because zero qualifies as falsy in JS:

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-669](https://helsinkisolutionoffice.atlassian.net/browse/KK-669)