### PR TITLE
KK-685 | Fix unremovable image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Zero recipient count being shown as a question mark
+- Image being unremovable after saving
 
 ## [1.5.4] - 2021-02-11
 

--- a/src/domain/events/api/EventApi.ts
+++ b/src/domain/events/api/EventApi.ts
@@ -64,6 +64,8 @@ const updateEvent: MethodHandler = async (params: MethodHandlerParams) => {
 
   if (params.data.image) {
     data.image = params.data.image.rawFile;
+  } else {
+    data.image = '';
   }
   data.eventGroupId = eventGroup ? eventGroup.id : null;
 


### PR DESCRIPTION
## Description

Sends an empty string as the value in the image field if no image exists so that the image is cleared.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-685](https://helsinkisolutionoffice.atlassian.net/browse/KK-685)

## Manual Testing Instructions for Reviewers

Images can be removed after they have been saved.