### PR TITLE
KK-782 | Fix incorrect total capacity label for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Occurrence notification subscription always being shown as 0
+- Total capacity count in event and event groups list
 
 ## [1.5.5] - 2021-04-26
 

--- a/src/api/generatedTypes/EventFragment.ts
+++ b/src/api/generatedTypes/EventFragment.ts
@@ -14,6 +14,10 @@ export interface EventFragment_occurrences_edges_node {
    * The ID of the object.
    */
   id: string;
+  /**
+   * When set will be used as the capacity of this occurrence instead of the value coming from the event.
+   */
+  capacityOverride: number | null;
 }
 
 export interface EventFragment_occurrences_edges {

--- a/src/api/generatedTypes/EventGroup.ts
+++ b/src/api/generatedTypes/EventGroup.ts
@@ -22,6 +22,10 @@ export interface EventGroup_eventGroup_events_edges_node_occurrences_edges_node 
    */
   id: string;
   enrolmentCount: number;
+  /**
+   * When set will be used as the capacity of this occurrence instead of the value coming from the event.
+   */
+  capacityOverride: number | null;
 }
 
 export interface EventGroup_eventGroup_events_edges_node_occurrences_edges {

--- a/src/api/generatedTypes/EventGroupEventFragment.ts
+++ b/src/api/generatedTypes/EventGroupEventFragment.ts
@@ -15,6 +15,10 @@ export interface EventGroupEventFragment_occurrences_edges_node {
    */
   id: string;
   enrolmentCount: number;
+  /**
+   * When set will be used as the capacity of this occurrence instead of the value coming from the event.
+   */
+  capacityOverride: number | null;
 }
 
 export interface EventGroupEventFragment_occurrences_edges {

--- a/src/api/generatedTypes/EventsAndEventGroups.ts
+++ b/src/api/generatedTypes/EventsAndEventGroups.ts
@@ -14,6 +14,10 @@ export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode_
    * The ID of the object.
    */
   id: string;
+  /**
+   * When set will be used as the capacity of this occurrence instead of the value coming from the event.
+   */
+  capacityOverride: number | null;
 }
 
 export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventNode_occurrences_edges {
@@ -52,6 +56,10 @@ export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroup
    * The ID of the object.
    */
   id: string;
+  /**
+   * When set will be used as the capacity of this occurrence instead of the value coming from the event.
+   */
+  capacityOverride: number | null;
 }
 
 export interface EventsAndEventGroups_eventsAndEventGroups_edges_node_EventGroupNode_events_edges_node_occurrences_edges {

--- a/src/domain/eventGroups/queries/EvenGroupQueries.ts
+++ b/src/domain/eventGroups/queries/EvenGroupQueries.ts
@@ -16,6 +16,7 @@ const EventGroupEventFragment = gql`
         node {
           id
           enrolmentCount
+          capacityOverride
         }
       }
     }

--- a/src/domain/events/__tests__/utils.test.js
+++ b/src/domain/events/__tests__/utils.test.js
@@ -5,7 +5,15 @@ describe('event utils', () => {
     const mockEvent = {
       capacityPerOccurrence: 5,
       occurrences: {
-        edges: [null, null, null],
+        edges: [
+          null,
+          null,
+          {
+            node: {
+              capacityOverride: 1,
+            },
+          },
+        ],
       },
     };
     const mockEventWithoutCapacity = {
@@ -16,11 +24,11 @@ describe('event utils', () => {
     };
 
     it('should return the capacity for an event', () => {
-      expect(countCapacity(mockEvent)).toEqual(15);
+      expect(countCapacity(mockEvent)).toEqual(11);
     });
 
     it('should return the capacity for many events', () => {
-      expect(countCapacity(mockEvent, mockEvent)).toEqual(30);
+      expect(countCapacity(mockEvent, mockEvent)).toEqual(22);
     });
 
     it('should return null if any event is missing a capacity', () => {

--- a/src/domain/eventsAndEventGroups/queries/EventsAndEventGroupsQueries.ts
+++ b/src/domain/eventsAndEventGroups/queries/EventsAndEventGroupsQueries.ts
@@ -14,6 +14,7 @@ const EventFragment = gql`
       edges {
         node {
           id
+          capacityOverride
         }
       }
     }


### PR DESCRIPTION
## Description

Fixes incorrect total capacity label fro events. Previously the `capacityOverride` field was ignored when total capacity was counted.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-782](https://helsinkisolutionoffice.atlassian.net/browse/KK-782)

## Screenshots

Before fix
<img width="1434" alt="Screenshot 2021-10-18 at 14 52 12" src="https://user-images.githubusercontent.com/9090689/137725124-e7a097ef-604d-4484-8d1c-57ef965bef8a.png">

After fix
<img width="1434" alt="Screenshot 2021-10-18 at 14 51 42" src="https://user-images.githubusercontent.com/9090689/137725165-ad56302e-1fdb-442b-9b6d-6c9b4f5fba0d.png">
