### PR TITLE
KK-783 | Fixed login routine when redirect target is unclear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Occurrence notification subscription always being shown as 0
 - Total capacity count in event and event groups list
-- Login routine failures when redirect target is unclear
+- Flaky login when redirect target was unclear or the sign in callback page itself
 
 ## [1.5.5] - 2021-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Error page for authentication
+
 ### Fixed
 
 - Occurrence notification subscription always being shown as 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Occurrence notification subscription always being shown as 0
 - Total capacity count in event and event groups list
+- Login routine failures when redirect target is unclear
 
 ## [1.5.5] - 2021-04-26
 

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -4,8 +4,7 @@
   },
   "authentication": {
     "callbackPage": {
-      "finishingAuthentication": "Finishing authentication",
-      "authorization": "Checking authorization"
+      "finishingAuthentication": "Finishing authentication"
     },
     "authError": {
       "title": "Login Failed",

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -3,8 +3,14 @@
     "test": "Test"
   },
   "authentication": {
-    "redirect": {
-      "text": "Authenticating..."
+    "callbackPage": {
+      "finishingAuthentication": "Finishing authentication",
+      "authorization": "Checking authorization"
+    },
+    "authError": {
+      "title": "Login Failed",
+      "description": "Log out and try again",
+      "logOut": "Log out"
     },
     "unauthorizedPage": {
       "backToLoginPage": "Back to login page",

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -5,11 +5,11 @@
   "authentication": {
     "callbackPage": {
       "finishingAuthentication": "Viimeistellään tunnistautumista",
-      "authorization": "Tarkistetaan lupia"
+      "authorization": "Tarkastetaan lupia"
     },
     "authError": {
       "title": "Kirjautuminen epäonnistui",
-      "description": "Kirjaudu ulos ja yritä udelleen",
+      "description": "Kirjaudu ulos ja yritä uudelleen",
       "logOut": "Kirjaudu ulos"
     },
     "unauthorizedPage": {

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -4,8 +4,7 @@
   },
   "authentication": {
     "callbackPage": {
-      "finishingAuthentication": "Viimeistellään tunnistautumista",
-      "authorization": "Tarkastetaan lupia"
+      "finishingAuthentication": "Viimeistellään tunnistautumista"
     },
     "authError": {
       "title": "Kirjautuminen epäonnistui",

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -3,8 +3,14 @@
     "test": "Testi"
   },
   "authentication": {
-    "redirect": {
-      "text": "Tunnistaudutaan..."
+    "callbackPage": {
+      "finishingAuthentication": "Viimeistellään tunnistautumista",
+      "authorization": "Tarkistetaan lupia"
+    },
+    "authError": {
+      "title": "Kirjautuminen epäonnistui",
+      "description": "Kirjaudu ulos ja yritä udelleen",
+      "logOut": "Kirjaudu ulos"
     },
     "unauthorizedPage": {
       "backToLoginPage": "Takaisin kirjautumissivulle",

--- a/src/domain/authentication/AuthErrorPage.tsx
+++ b/src/domain/authentication/AuthErrorPage.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import Button from '@material-ui/core/Button';
+import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import { useTranslate, useLogout } from 'react-admin';
+import Box from '@material-ui/core/Box';
+
+import InfoPageTemplate from './InfoPageTemplate';
+
+export default function AuthError() {
+  const t = useTranslate();
+  const logout = useLogout();
+
+  const handleLogoutButtonClick = () => {
+    logout();
+  };
+
+  return (
+    <InfoPageTemplate
+      title={t('authentication.authError.title')}
+      content={
+        <>
+          {t('authentication.authError.description')}
+          <Box style={{ marginTop: '2rem' }}>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={handleLogoutButtonClick}
+              startIcon={<ExitToAppIcon />}
+            >
+              {t('ra.auth.logout')}
+            </Button>
+          </Box>
+        </>
+      }
+    />
+  );
+}

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -49,13 +49,12 @@ function CallBackPage({
       });
   }, [dataProvider, history, pathname, t]);
 
+  if (error) {
+    return <AuthError />;
+  }
+
   return (
-    <>
-      {!error && (
-        <Loading loadingPrimary="authentication.callbackPage.finishingAuthentication" />
-      )}
-      {error && <AuthError />}
-    </>
+    <Loading loadingPrimary="authentication.callbackPage.finishingAuthentication" />
   );
 }
 

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -1,11 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  useTranslate,
-  useNotify,
-  useDataProvider,
-  useLogout,
-  Loading,
-} from 'react-admin';
+import { useTranslate, useNotify, useDataProvider, Loading } from 'react-admin';
 import { RouteComponentProps } from 'react-router';
 import * as Sentry from '@sentry/browser';
 import { User } from 'oidc-client';
@@ -20,7 +14,6 @@ function CallBackPage({ history }: RouteComponentProps) {
   const t = useTranslate();
   const notify = useNotify();
   const dataProvider = useDataProvider();
-  const logout = useLogout();
   const [phase, setPhase] = useState<CallbackPageState>('authentication');
 
   useEffect(() => {
@@ -42,7 +35,7 @@ function CallBackPage({ history }: RouteComponentProps) {
         notify(t('ra.message.error'), 'warning');
         Sentry.captureException(error);
       });
-  }, [dataProvider, history, logout, notify, t]);
+  }, [dataProvider, history, notify, t]);
 
   return (
     <>

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useTranslate, useNotify, useDataProvider, Loading } from 'react-admin';
+import { useTranslate, useDataProvider, Loading } from 'react-admin';
 import { RouteComponentProps } from 'react-router';
 import * as Sentry from '@sentry/browser';
 import { User } from 'oidc-client';
@@ -28,7 +28,6 @@ function CallBackPage({
   location: { pathname },
 }: RouteComponentProps) {
   const t = useTranslate();
-  const notify = useNotify();
   const dataProvider = useDataProvider();
   const [phase, setPhase] = useState<CallbackPageState>('authentication');
 
@@ -50,10 +49,9 @@ function CallBackPage({
         setPhase('error');
         // Clear auth state from the failed login attempt
         authService.resetAuthState();
-        notify(t('ra.message.error'), 'warning');
         Sentry.captureException(error);
       });
-  }, [dataProvider, history, notify, pathname, t]);
+  }, [dataProvider, history, pathname, t]);
 
   return (
     <>

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -8,9 +8,25 @@ import authService from './authService';
 import authorizationService from './authorizationService';
 import AuthError from './AuthErrorPage';
 
+function getRedirectPath(
+  redirectTarget: string | undefined | string,
+  currentPathname: string
+): string {
+  // If the redirectTarget is the same as the current pathname, redirect to
+  // default view instead.
+  if (!redirectTarget || redirectTarget === currentPathname) {
+    return '/';
+  }
+
+  return redirectTarget;
+}
+
 type CallbackPageState = 'authentication' | 'authorization' | 'error';
 
-function CallBackPage({ history }: RouteComponentProps) {
+function CallBackPage({
+  history,
+  location: { pathname },
+}: RouteComponentProps) {
   const t = useTranslate();
   const notify = useNotify();
   const dataProvider = useDataProvider();
@@ -27,7 +43,7 @@ function CallBackPage({ history }: RouteComponentProps) {
         if (role === 'none') {
           history.replace('/unauthorized');
         } else {
-          history.replace(user.state?.path ?? '');
+          history.replace(getRedirectPath(user.state?.path, pathname));
         }
       })
       .catch((error) => {
@@ -35,7 +51,7 @@ function CallBackPage({ history }: RouteComponentProps) {
         notify(t('ra.message.error'), 'warning');
         Sentry.captureException(error);
       });
-  }, [dataProvider, history, notify, t]);
+  }, [dataProvider, history, notify, pathname, t]);
 
   return (
     <>

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -48,6 +48,8 @@ function CallBackPage({
       })
       .catch((error) => {
         setPhase('error');
+        // Clear auth state from the failed login attempt
+        authService.resetAuthState();
         notify(t('ra.message.error'), 'warning');
         Sentry.captureException(error);
       });

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -21,22 +21,18 @@ function getRedirectPath(
   return redirectTarget;
 }
 
-type CallbackPageState = 'authentication' | 'authorization' | 'error';
-
 function CallBackPage({
   history,
   location: { pathname },
 }: RouteComponentProps) {
   const t = useTranslate();
   const dataProvider = useDataProvider();
-  const [phase, setPhase] = useState<CallbackPageState>('authentication');
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     authService
       .endLogin()
       .then((user: User) => {
-        setPhase('authorization');
-
         const role = authorizationService.getRole();
 
         if (role === 'none') {
@@ -46,7 +42,7 @@ function CallBackPage({
         }
       })
       .catch((error) => {
-        setPhase('error');
+        setError(error);
         // Clear auth state from the failed login attempt
         authService.resetAuthState();
         Sentry.captureException(error);
@@ -55,13 +51,10 @@ function CallBackPage({
 
   return (
     <>
-      {phase === 'authentication' && (
+      {!error && (
         <Loading loadingPrimary="authentication.callbackPage.finishingAuthentication" />
       )}
-      {phase === 'authorization' && (
-        <Loading loadingPrimary="authentication.callbackPage.authorization" />
-      )}
-      {phase === 'error' && <AuthError />}
+      {error && <AuthError />}
     </>
   );
 }

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -27,7 +27,7 @@ function CallBackPage({ history }: RouteComponentProps) {
         if (role === 'none') {
           history.replace('/unauthorized');
         } else {
-          history.replace(user?.state.path);
+          history.replace(user.state?.path ?? '');
         }
       })
       .catch((error) => {

--- a/src/domain/authentication/CallbackPage.tsx
+++ b/src/domain/authentication/CallbackPage.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   useTranslate,
   useNotify,
   useDataProvider,
   useLogout,
+  Loading,
 } from 'react-admin';
 import { RouteComponentProps } from 'react-router';
 import * as Sentry from '@sentry/browser';
@@ -11,17 +12,23 @@ import { User } from 'oidc-client';
 
 import authService from './authService';
 import authorizationService from './authorizationService';
+import AuthError from './AuthErrorPage';
+
+type CallbackPageState = 'authentication' | 'authorization' | 'error';
 
 function CallBackPage({ history }: RouteComponentProps) {
   const t = useTranslate();
   const notify = useNotify();
   const dataProvider = useDataProvider();
   const logout = useLogout();
+  const [phase, setPhase] = useState<CallbackPageState>('authentication');
 
   useEffect(() => {
     authService
       .endLogin()
       .then((user: User) => {
+        setPhase('authorization');
+
         const role = authorizationService.getRole();
 
         if (role === 'none') {
@@ -31,13 +38,23 @@ function CallBackPage({ history }: RouteComponentProps) {
         }
       })
       .catch((error) => {
+        setPhase('error');
         notify(t('ra.message.error'), 'warning');
         Sentry.captureException(error);
-        logout();
       });
   }, [dataProvider, history, logout, notify, t]);
 
-  return <p>{t('authentication.redirect.text')}</p>;
+  return (
+    <>
+      {phase === 'authentication' && (
+        <Loading loadingPrimary="authentication.callbackPage.finishingAuthentication" />
+      )}
+      {phase === 'authorization' && (
+        <Loading loadingPrimary="authentication.callbackPage.authorization" />
+      )}
+      {phase === 'error' && <AuthError />}
+    </>
+  );
 }
 
 export default CallBackPage;

--- a/src/domain/authentication/InfoPageTemplate.tsx
+++ b/src/domain/authentication/InfoPageTemplate.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CardHeader from '@material-ui/core/CardHeader';
+import Container from '@material-ui/core/Container';
+import { ThemeProvider, makeStyles } from '@material-ui/styles';
+
+import theme from '../../common/materialUI/themeConfig';
+
+const useStyles = makeStyles(() => ({
+  background: {
+    height: '100vh',
+    width: '100vw',
+    display: 'flex',
+    justifyContent: 'center',
+    background:
+      'radial-gradient(circle at 50% 14em, #313264 0%, #00023b 60%, #00023b 100%)',
+  },
+  container: {
+    marginTop: '6em',
+  },
+}));
+
+type Props = {
+  title: string;
+  content: React.ReactNode;
+};
+
+const InfoPageTemplate = ({ title, content }: Props) => {
+  const classes = useStyles();
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div className={classes.background}>
+        <Container maxWidth="sm" className={classes.container}>
+          <Card style={{ textAlign: 'center' }}>
+            <CardHeader title={title} />
+            <CardContent>{content}</CardContent>
+          </Card>
+        </Container>
+      </div>
+    </ThemeProvider>
+  );
+};
+
+export default InfoPageTemplate;

--- a/src/domain/authentication/UnauthorizedPage.tsx
+++ b/src/domain/authentication/UnauthorizedPage.tsx
@@ -1,57 +1,31 @@
 import React from 'react';
 import { useLogout, useTranslate } from 'react-admin';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import CardHeader from '@material-ui/core/CardHeader';
-import Container from '@material-ui/core/Container';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
-import { ThemeProvider, makeStyles } from '@material-ui/styles';
 
-import theme from '../../common/materialUI/themeConfig';
-
-const useStyles = makeStyles(() => ({
-  background: {
-    height: '100vh',
-    width: '100vw',
-    display: 'flex',
-    justifyContent: 'center',
-    background:
-      'radial-gradient(circle at 50% 14em, #313264 0%, #00023b 60%, #00023b 100%)',
-  },
-  container: {
-    marginTop: '6em',
-  },
-}));
+import InfoPageTemplate from './InfoPageTemplate';
 
 const UnauthorizedPage = () => {
   const translate = useTranslate();
   const logout = useLogout();
-  const classes = useStyles();
   const contactEmail = translate(
     'authentication.unauthorizedPage.contactEmail'
   );
   return (
-    <ThemeProvider theme={theme}>
-      <div className={classes.background}>
-        <Container maxWidth="sm" className={classes.container}>
-          <Card style={{ textAlign: 'center' }}>
-            <CardHeader
-              title={translate('authentication.unauthorizedPage.title')}
-            />
-            <CardContent>
-              {translate('authentication.unauthorizedPage.content')}{' '}
-              <a href={'mailto:' + contactEmail}>{contactEmail}</a>
-              <Box style={{ marginTop: '2rem' }}>
-                <Button variant="contained" color="secondary" onClick={logout}>
-                  {translate('ra.auth.logout')}
-                </Button>
-              </Box>
-            </CardContent>
-          </Card>
-        </Container>
-      </div>
-    </ThemeProvider>
+    <InfoPageTemplate
+      title={translate('authentication.unauthorizedPage.title')}
+      content={
+        <>
+          {translate('authentication.unauthorizedPage.content')}{' '}
+          <a href={'mailto:' + contactEmail}>{contactEmail}</a>
+          <Box style={{ marginTop: '2rem' }}>
+            <Button variant="contained" color="secondary" onClick={logout}>
+              {translate('ra.auth.logout')}
+            </Button>
+          </Box>
+        </>
+      }
+    />
   );
 };
 export default UnauthorizedPage;

--- a/src/domain/authentication/authService.ts
+++ b/src/domain/authentication/authService.ts
@@ -52,6 +52,7 @@ export class AuthService {
     this.endLogin = this.endLogin.bind(this);
     this.renewToken = this.renewToken.bind(this);
     this.logout = this.logout.bind(this);
+    this.resetAuthState = this.resetAuthState.bind(this);
 
     // Events
     this.userManager.events.addAccessTokenExpired(() => {
@@ -63,9 +64,7 @@ export class AuthService {
     });
 
     this.userManager.events.addUserSignedOut(() => {
-      this.userManager.clearStaleState();
-      authorizationService.clear();
-      localStorage.removeItem(API_TOKEN);
+      this.resetAuthState();
     });
 
     this.userManager.events.addUserLoaded(async (user) => {

--- a/src/domain/authentication/authService.ts
+++ b/src/domain/authentication/authService.ts
@@ -117,11 +117,15 @@ export class AuthService {
     return this.userManager.signinSilent();
   }
 
-  public async logout(): Promise<void> {
+  public resetAuthState() {
     localStorage.removeItem(API_TOKEN);
     projectService.clear();
     this.userManager.clearStaleState();
     authorizationService.clear();
+  }
+
+  public async logout(): Promise<void> {
+    this.resetAuthState();
     await this.userManager.signoutRedirect();
   }
 

--- a/src/domain/authentication/authService.ts
+++ b/src/domain/authentication/authService.ts
@@ -96,8 +96,10 @@ export class AuthService {
     try {
       return this.userManager.signinRedirect({ data: { path } });
     } catch (error) {
-      if (error.message !== 'Network Error') {
-        Sentry.captureException(error);
+      if (error instanceof Error) {
+        if (error.message !== 'Network Error') {
+          Sentry.captureException(error);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

I was able to reproduce a login issue once and I tracked it down into this phase of the login routine. With an `undefined` value the login process hangs indefinitely in `/callback`. By providing a default value the user will always have a redirect target.

When I tested this approach against the information in the ticket, it's hard to say whether this is an issue some of the users have faced. If you get stuck on the `/callback` route and refresh, you get logged out (the system attempts to end the login routine again, but none is currently taking place, in which case the system errors and logs the user out in order to create a clean slate for the next attempt). Similarly, using the back button will take you out of the service into the authentication provider (in my case GitHub). The page the service returns would most likely be an error page for similar reasons as described above--that particular login attempt has already been completed.

I made the login routine a bit more transparent to the user by:
- Informing them about permission checking (if routine hangs here, it'll show in screen shots etc)
- Showing an error page on failure instead of logging out (user has time to discern that there was an error--on logout they are redirected out of the service)

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-783](https://helsinkisolutionoffice.atlassian.net/browse/KK-783)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->