### PR TITLE
KK-814 | Use new authentication error codes

### DIFF
--- a/src/api/__tests__/client.tests.js
+++ b/src/api/__tests__/client.tests.js
@@ -85,6 +85,12 @@ describe('client', () => {
             extensions: {},
           },
           {
+            message: 'foobar',
+            extensions: {
+              code: 'AUTHENTICATION_EXPIRED_ERROR',
+            },
+          },
+          {
             message: '123',
             extensions: {
               code: 'PERMISSION_DENIED_ERROR',
@@ -128,7 +134,8 @@ describe('client', () => {
         graphQLErrors
           .map(
             (graphQLError) =>
-              `[GraphQL error]: Message: ${graphQLError.message}, Location: ${graphQLError.locations}, Path: ${graphQLError.path}`
+              // eslint-disable-next-line max-len
+              `[GraphQL error]: Message: ${graphQLError.message}, Code: ${graphQLError.extensions?.code}, Location: ${graphQLError.locations}, Path: ${graphQLError.path}`
           )
           .forEach((errorMessage) => {
             expect(consoleErrorSpy).toHaveBeenCalledWith(errorMessage);

--- a/src/api/utils/apiUtils.ts
+++ b/src/api/utils/apiUtils.ts
@@ -4,7 +4,6 @@ import {
   MutationOptions,
 } from '@apollo/client';
 import { HttpError } from 'react-admin';
-import * as Sentry from '@sentry/browser';
 
 import client from '../client';
 import { API_ERROR_MESSAGE } from '../constants/ApiConstants';
@@ -28,22 +27,6 @@ export const queryHandler = async (
     const res = await client.query(queryOptions);
     return res;
   } catch (error) {
-    if (
-      error.message ===
-      'GraphQL error: Invalid Authorization header. JWT has expired.'
-    ) {
-      // JWT has expired. Probably because user has been offline. Remove old apiToken to trigger logout
-      localStorage.removeItem('apiToken');
-    } else if (
-      error.graphQLErrors[0].extensions.code === 'PERMISSION_DENIED_ERROR'
-    ) {
-      // eslint-disable-next-line no-console
-      console.error('Permission denied');
-    } else {
-      // eslint-disable-next-line no-console
-      console.error(error);
-      Sentry.captureException(error);
-    }
     throw new HttpError(error.message || API_ERROR_MESSAGE, error.status);
   }
 };
@@ -54,9 +37,6 @@ export const mutationHandler = async (
   try {
     return await client.mutate(mutationOptions);
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(error);
-    Sentry.captureException(error);
     throw new HttpError(error.message || API_ERROR_MESSAGE, error.status);
   }
 };


### PR DESCRIPTION
## Description

Implemented handling of the backend's new authentication-related error codes. Also while at it, removed duplicate error handling from `handleQuery()` and `handleMutation()` helper functions. Now all error handling happens in the Apollo client's error link.

## Context

[KK-814](https://helsinkisolutionoffice.atlassian.net/browse/KK-814>)
