### PR TITLE
KK-824 | Hide event selection when invited recipients is selected in message creation

### DIFF
--- a/src/domain/messages/choices.ts
+++ b/src/domain/messages/choices.ts
@@ -1,4 +1,11 @@
-export const recipientSelectionChoices = [
+export type RecipientId =
+  | 'ALL'
+  | 'INVITED'
+  | 'ENROLLED'
+  | 'ATTENDED'
+  | 'SUBSCRIBED_TO_FREE_SPOT_NOTIFICATION';
+
+export const recipientSelectionChoices: { id: RecipientId; name: string }[] = [
   {
     id: 'ALL',
     name: 'messages.fields.recipientSelection.choices.ALL.label',
@@ -20,4 +27,10 @@ export const recipientSelectionChoices = [
     name:
       'messages.fields.recipientSelection.choices.SUBSCRIBED_TO_FREE_SPOT_NOTIFICATION.label',
   },
+];
+
+export const recipientsWithEventSelection: RecipientId[] = [
+  'ENROLLED',
+  'ATTENDED',
+  'SUBSCRIBED_TO_FREE_SPOT_NOTIFICATION',
 ];

--- a/src/domain/messages/form/MessageForm.tsx
+++ b/src/domain/messages/form/MessageForm.tsx
@@ -18,7 +18,10 @@ import {
   validateBodyText,
   validateMessageForm,
 } from '../validations';
-import { recipientSelectionChoices } from '../choices';
+import {
+  recipientSelectionChoices,
+  recipientsWithEventSelection,
+} from '../choices';
 
 const CustomOnChange = ({ children, onChange, ...rest }: any) => {
   const form = useForm();
@@ -127,7 +130,7 @@ const MessageForm = (props: Props) => {
       </CustomOnChange>
       <FormDataConsumer formClassName={classes.event}>
         {({ formData: { recipientSelection }, ...rest }) =>
-          recipientSelection !== 'ALL' && (
+          recipientsWithEventSelection.includes(recipientSelection) && (
             <CustomOnChange onChange={handleEvenIdChange}>
               <EventSelect
                 {...rest}

--- a/src/domain/messages/form/__tests__/MessageForm.test.jsx
+++ b/src/domain/messages/form/__tests__/MessageForm.test.jsx
@@ -53,12 +53,13 @@ const chooseSelectInputOption = async (container, selectInput, optionLabel) => {
 };
 
 describe('<MessageForm />', () => {
-  it('should not show event select unless the user has chosen some other recipient count than all', async () => {
+  it('should not show event select unless the user has chosen some other recipient count than all or invited', async () => {
     const { container, queryAllByText } = getWrapper();
 
     expect(
       querySelectInputByLabelText(container, 'messages.fields.event.label')
     ).toBeFalsy();
+    expect(queryAllByText('messages.fields.event.label').length).toBe(0);
 
     await chooseSelectInputOption(
       container,
@@ -67,6 +68,17 @@ describe('<MessageForm />', () => {
         'messages.fields.recipientSelection.label'
       ),
       'messages.fields.recipientSelection.choices.INVITED.label'
+    );
+
+    expect(queryAllByText('messages.fields.event.label').length).toBe(0);
+
+    await chooseSelectInputOption(
+      container,
+      getSelectInputByLabelText(
+        container,
+        'messages.fields.recipientSelection.label'
+      ),
+      'messages.fields.recipientSelection.choices.ENROLLED.label'
     );
 
     expect(


### PR DESCRIPTION
## Description

Hide event selection when invited recipients is selected in message creation

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-824](https://helsinkisolutionoffice.atlassian.net/browse/<jira-id>)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots
<img width="835" alt="Screenshot 2021-12-16 at 10 00 04" src="https://user-images.githubusercontent.com/15219142/146331324-401b3706-a45d-4a00-a12c-943bd3328ec6.png">

