### PR TITLE
KK-508 | Add ticket validation view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Ticket validation view
+
 ## [1.6.1] - 2021-12-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.2.7",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@sentry/browser": "^5.20.0",
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^10.4.7",

--- a/src/api/apolloClient/__tests__/client.tests.js
+++ b/src/api/apolloClient/__tests__/client.tests.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
-import Config from '../../domain/config';
-import { handleError } from '../client';
+import Config from '../../../domain/config';
+import handleError from '../handleApolloError';
 
 const graphQLError = {
   message: 'Message',
@@ -25,7 +25,7 @@ const operation = {
 };
 
 describe('client', () => {
-  describe('handleError', () => {
+  describe('handleApolloError', () => {
     const mockScope = {
       setLevel: jest.fn(),
       setTag: jest.fn(),

--- a/src/api/apolloClient/client.ts
+++ b/src/api/apolloClient/client.ts
@@ -1,0 +1,44 @@
+/* eslint-disable no-console */
+import { ApolloClient, ApolloLink } from '@apollo/client';
+import { InMemoryCache } from '@apollo/client/cache';
+import { setContext } from '@apollo/client/link/context';
+import { onError } from '@apollo/client/link/error';
+import { createUploadLink } from 'apollo-upload-client';
+
+import i18nProvider from '../../common/translation/i18nProvider';
+import handleApolloError from './handleApolloError';
+
+const uploadLink = createUploadLink({
+  uri: process.env.REACT_APP_API_URI,
+  headers: {
+    'keep-alive': 'true',
+  },
+});
+
+const errorLink = onError(handleApolloError);
+
+const authLink = setContext((_, { headers }) => {
+  const token = localStorage.getItem('apiToken');
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : null,
+      'accept-language': i18nProvider.getLocale() || 'fi',
+    },
+  };
+});
+
+const client = new ApolloClient({
+  link: ApolloLink.from([errorLink, authLink, uploadLink]),
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: 'no-cache',
+    },
+    query: {
+      fetchPolicy: 'no-cache',
+    },
+  },
+  cache: new InMemoryCache(),
+});
+
+export default client;

--- a/src/api/apolloClient/unauthenticatedClient.ts
+++ b/src/api/apolloClient/unauthenticatedClient.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, ApolloLink } from '@apollo/client';
+import { ApolloClient, ApolloLink, HttpLink } from '@apollo/client';
 import { InMemoryCache } from '@apollo/client/cache';
 import { onError } from '@apollo/client/link/error';
 
@@ -6,8 +6,12 @@ import handleApolloError from './handleApolloError';
 
 const errorLink = onError(handleApolloError);
 
+const httpLink = new HttpLink({
+  uri: process.env.REACT_APP_API_URI,
+});
+
 const unauthenticatedClient = new ApolloClient({
-  link: ApolloLink.from([errorLink]),
+  link: ApolloLink.from([errorLink, httpLink]),
   defaultOptions: {
     watchQuery: {
       fetchPolicy: 'no-cache',

--- a/src/api/apolloClient/unauthenticatedClient.ts
+++ b/src/api/apolloClient/unauthenticatedClient.ts
@@ -1,0 +1,22 @@
+import { ApolloClient, ApolloLink } from '@apollo/client';
+import { InMemoryCache } from '@apollo/client/cache';
+import { onError } from '@apollo/client/link/error';
+
+import handleApolloError from './handleApolloError';
+
+const errorLink = onError(handleApolloError);
+
+const unauthenticatedClient = new ApolloClient({
+  link: ApolloLink.from([errorLink]),
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: 'no-cache',
+    },
+    query: {
+      fetchPolicy: 'no-cache',
+    },
+  },
+  cache: new InMemoryCache(),
+});
+
+export default unauthenticatedClient;

--- a/src/api/generatedTypes/VerifyTicket.ts
+++ b/src/api/generatedTypes/VerifyTicket.ts
@@ -1,0 +1,32 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: VerifyTicket
+// ====================================================
+
+export interface VerifyTicket_verifyTicket {
+  /**
+   * The time of the event occurrence
+   */
+  occurrenceTime: any;
+  /**
+   * The name of the event
+   */
+  eventName: string;
+  /**
+   * The name of the venue
+   */
+  venueName: string | null;
+  validity: boolean;
+}
+
+export interface VerifyTicket {
+  verifyTicket: VerifyTicket_verifyTicket | null;
+}
+
+export interface VerifyTicketVariables {
+  referenceId: string;
+}

--- a/src/api/utils/apiUtils.ts
+++ b/src/api/utils/apiUtils.ts
@@ -5,7 +5,7 @@ import {
 } from '@apollo/client';
 import { HttpError } from 'react-admin';
 
-import client from '../client';
+import client from '../apolloClient/client';
 import { API_ERROR_MESSAGE } from '../constants/ApiConstants';
 import {
   Nullish,

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -465,5 +465,10 @@
   },
   "generic": {
     "all": "All"
+  },
+  "ticketValidation": {
+    "valid": "Ticket is valid",
+    "invalid": "Ticket is not valid",
+    "error": "TIcket validation failed"
   }
 }

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -469,6 +469,6 @@
   "ticketValidation": {
     "valid": "Ticket is valid",
     "invalid": "Ticket is not valid",
-    "error": "TIcket validation failed"
+    "error": "Ticket validation failed"
   }
 }

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -465,5 +465,10 @@
   },
   "generic": {
     "all": "Kaikki"
+  },
+  "ticketValidation": {
+    "valid": "Lippu on voimassa",
+    "invalid": "Lippu ei ole voimassa",
+    "error": "Lipun tarkistaminen epäonnistui"
   }
 }

--- a/src/domain/ticketValidation/OccurrenceCard.tsx
+++ b/src/domain/ticketValidation/OccurrenceCard.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+
+import { toShortDateTimeString } from '../../common/utils';
+
+const useStyles = makeStyles({
+  title: {
+    fontSize: 14,
+  },
+  container: {
+    '&:last-child': {
+      paddingBottom: 16,
+    },
+  },
+});
+
+type Props = {
+  eventName: string;
+  venueName: string;
+  occurrenceTime: string;
+};
+
+const OccurrenceCard = ({ eventName, venueName, occurrenceTime }: Props) => {
+  const classes = useStyles();
+
+  return (
+    <Card>
+      <CardContent className={classes.container}>
+        <Typography className={classes.title} color="textSecondary">
+          {toShortDateTimeString(new Date(occurrenceTime))}
+        </Typography>
+        <Typography variant="h5" component="h2">
+          {eventName}
+        </Typography>
+        <Typography color="textSecondary">{venueName}</Typography>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default OccurrenceCard;

--- a/src/domain/ticketValidation/TicketValidationPage.tsx
+++ b/src/domain/ticketValidation/TicketValidationPage.tsx
@@ -3,7 +3,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import CancelIcon from '@material-ui/icons/Cancel';
 import { useParams } from 'react-router';
-import { useTranslate } from 'react-admin';
+import { useTranslate, Loading } from 'react-admin';
 import Typography from '@material-ui/core/Typography';
 import Alert from '@material-ui/lab/Alert';
 import { ApolloProvider } from '@apollo/client';
@@ -40,11 +40,15 @@ const TicketValidationPage = () => {
   const t = useTranslate();
   const styles = useStyles();
   const { cryptographicallySignedCode } = useParams<Params>();
-  const { data, error } = useVerifyTicketQuery({
+  const { data, error, loading } = useVerifyTicketQuery({
     referenceId: cryptographicallySignedCode,
   });
   const { validity: isValid, eventName, venueName, occurrenceTime } =
     data?.verifyTicket ?? {};
+
+  if (loading) {
+    return <Loading />;
+  }
 
   if (error) {
     return (

--- a/src/domain/ticketValidation/TicketValidationPage.tsx
+++ b/src/domain/ticketValidation/TicketValidationPage.tsx
@@ -43,10 +43,8 @@ const TicketValidationPage = () => {
   const { data, error } = useVerifyTicketQuery({
     referenceId: cryptographicallySignedCode,
   });
-  const isValid = data?.verifyTicket?.validity;
-  const eventName = data?.verifyTicket?.eventName;
-  const venueName = data?.verifyTicket?.venueName;
-  const occurrenceTime = data?.verifyTicket?.occurrenceTime;
+  const { validity: isValid, eventName, venueName, occurrenceTime } =
+    data?.verifyTicket ?? {};
 
   if (error) {
     return (

--- a/src/domain/ticketValidation/TicketValidationPage.tsx
+++ b/src/domain/ticketValidation/TicketValidationPage.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CancelIcon from '@material-ui/icons/Cancel';
+import { useParams } from 'react-router';
+import { useTranslate } from 'react-admin';
+import Typography from '@material-ui/core/Typography';
+import Alert from '@material-ui/lab/Alert';
+import { ApolloProvider } from '@apollo/client';
+
+import unauthenticatedClient from '../../api/apolloClient/unauthenticatedClient';
+import useVerifyTicketQuery from './useVerifyTicketQuery';
+import OccurrenceCard from './OccurrenceCard';
+
+const containerStyles = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: '100vh',
+} as const;
+
+const useStyles = makeStyles((theme) => ({
+  errorContainer: {
+    ...containerStyles,
+  },
+  container: {
+    ...containerStyles,
+    rowGap: `${theme.spacing(3)}px`,
+
+    backgroundColor: theme.palette.grey[200],
+  },
+}));
+
+type Params = {
+  cryptographicallySignedCode: string;
+};
+
+const TicketValidationPage = () => {
+  const t = useTranslate();
+  const styles = useStyles();
+  const { cryptographicallySignedCode } = useParams<Params>();
+  const { data, error } = useVerifyTicketQuery({
+    referenceId: cryptographicallySignedCode,
+  });
+  const isValid = data?.verifyTicket?.validity;
+  const eventName = data?.verifyTicket?.eventName;
+  const venueName = data?.verifyTicket?.venueName;
+  const occurrenceTime = data?.verifyTicket?.occurrenceTime;
+
+  if (error) {
+    return (
+      <div className={styles.errorContainer}>
+        <Alert severity="error">{t('ticketValidation.error')}</Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <ValidityIndicator isValid={isValid} />
+      <OccurrenceCard
+        eventName={eventName}
+        venueName={venueName}
+        occurrenceTime={occurrenceTime}
+      />
+    </div>
+  );
+};
+
+type ValidityIndicatorProps = {
+  isValid: boolean;
+};
+
+const useValidStyles = makeStyles<Theme, ValidityIndicatorProps>((theme) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    rowGap: `${theme.spacing(1)}px`,
+  },
+  icon: {
+    fontSize: '6rem',
+    color: ({ isValid }) =>
+      isValid ? theme.palette.success.main : theme.palette.error.main,
+  },
+}));
+
+const ValidityIndicator = ({ isValid }: ValidityIndicatorProps) => {
+  const t = useTranslate();
+  const styles = useValidStyles({ isValid });
+
+  return (
+    <div className={styles.container}>
+      {React.createElement(isValid ? CheckCircleIcon : CancelIcon, {
+        className: styles.icon,
+      })}
+      <Typography component="h1" variant="h5">
+        {t(isValid ? 'ticketValidation.valid' : 'ticketValidation.invalid')}
+      </Typography>
+    </div>
+  );
+};
+
+const TicketValidationPageWithApolloProvider = () => (
+  <ApolloProvider client={unauthenticatedClient}>
+    <TicketValidationPage />
+  </ApolloProvider>
+);
+
+export default TicketValidationPageWithApolloProvider;

--- a/src/domain/ticketValidation/useVerifyTicketQuery.ts
+++ b/src/domain/ticketValidation/useVerifyTicketQuery.ts
@@ -1,0 +1,22 @@
+import { gql, useQuery } from '@apollo/client';
+
+const verifyTicketQuery = gql`
+  query VerifyTicket($referenceId: String!) {
+    verifyTicket(referenceId: $referenceId) {
+      occurrenceTime
+      eventName
+      venueName
+      validity
+    }
+  }
+`;
+
+type Config = {
+  referenceId: string;
+};
+
+export default function useVerifyTicketQuery({ referenceId }: Config) {
+  return useQuery(verifyTicketQuery, {
+    variables: { referenceId },
+  });
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,10 +8,17 @@ import { Route, Redirect } from 'react-router';
 
 import CallbackPage from './domain/authentication/CallbackPage';
 import UnauthorizedPage from './domain/authentication/UnauthorizedPage';
+import TicketValidationPage from './domain/ticketValidation/TicketValidationPage';
 
 export default [
   <Route exact path="/callback" component={CallbackPage} noLayout />,
   <Route exact path="/unauthorized" component={UnauthorizedPage} noLayout />,
+  <Route
+    exact
+    path="/check-ticket-validity/:cryptographicallySignedCode"
+    component={TicketValidationPage}
+    noLayout
+  />,
   <Redirect exact from="/event-groups" to="/events-and-event-groups" />,
   <Redirect exact path="/events" to="/events-and-event-groups" />,
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,6 +1472,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.60":
+  version "4.0.0-alpha.60"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz#5ad203aed5a8569b0f1753945a21a05efa2234d2"
+  integrity sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+
 "@material-ui/styles@^4.10.0", "@material-ui/styles@^4.3.3":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.10.0.tgz#2406dc23aa358217aa8cc772e6237bd7f0544071"
@@ -1517,6 +1528,15 @@
     "@babel/runtime" "^7.4.4"
     prop-types "^15.7.2"
     react-is "^16.8.0"
+
+"@material-ui/utils@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.11.2.tgz#f1aefa7e7dff2ebcb97d31de51aecab1bb57540a"
+  integrity sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -12119,6 +12139,11 @@ react-is@^16.12.0, react-is@^16.5.2, react-is@^16.6.0, react-is@^16.7.0, react-i
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+"react-is@^16.8.0 || ^17.0.0":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-is@^17.0.1:
   version "17.0.1"


### PR DESCRIPTION
## Description

Adds a new page into the admin UI: `/check-ticket-validity/:cryptographicallySignedCode`

The `cryptographicallySignedCode` is used to make a query into the backend that returns validity (and some other details) about a ticket.

In case of error, a generic error view gets shown.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-508](https://helsinkisolutionoffice.atlassian.net/browse/KK-508)

## Screenshots

<img width="313" alt="Screenshot 2022-02-22 at 13 42 51" src="https://user-images.githubusercontent.com/9090689/156154491-e787eb30-cf13-4ed7-8838-f0547c801637.png">
