### PR TITLE
Event group republish features and status indicators

### DIFF
--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -202,6 +202,7 @@
         "do": "New Event Group"
       },
       "publish": {
+        "redo": "Republish Event Group",
         "do": "Publish Event Group",
         "success": "Event group published!",
         "error": "Event group publish error",

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -153,7 +153,8 @@
         "label2": "Status",
         "options": {
           "ready": "Ready",
-          "notReady": "Unfinished"
+          "notReady": "Unfinished",
+          "published": "Published"
         }
       },
       "ticketSystem": {

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -202,6 +202,7 @@
         "do": "Uusi tapahtumaryhmä"
       },
       "publish": {
+        "redo": "Uudelleen julkaise tapahtumaryhmä",
         "do": "Julkaise tapahtumaryhmä",
         "success": "Tapahtumaryhmä julkaistu!",
         "error": "Tapahtumaryhmän julkaisussa tapahtui virhe.",

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -153,7 +153,8 @@
         "label2": "Tila",
         "options": {
           "ready": "Valmis",
-          "notReady": "Keskeneräinen"
+          "notReady": "Keskeneräinen",
+          "published": "Julkaistu"
         }
       },
       "ticketSystem": {

--- a/src/domain/eventGroups/detail/EventGroupsDetailActions.tsx
+++ b/src/domain/eventGroups/detail/EventGroupsDetailActions.tsx
@@ -8,6 +8,10 @@ import {
 import { makeStyles } from '@material-ui/core';
 
 import PublishEventGroupButton from './PublishEventGroupButton';
+import {
+  EventGroupEventsPublishStatusEnum,
+  getEventGroupPublishStatus,
+} from '../utils';
 
 const useStyles = makeStyles((theme) => ({
   toolbar: {
@@ -21,12 +25,18 @@ const useStyles = makeStyles((theme) => ({
 const EventGroupsDetailActions = ({ data, basePath, permissions }: any) => {
   const t = useTranslate();
   const classes = useStyles();
-
-  const isPublished = Boolean(data?.publishedAt);
+  const publishStatus = getEventGroupPublishStatus(data);
   const canPublish = permissions?.canPublishWithinProject(data?.project?.id);
   const canManageEventGroups = permissions?.canManageEventGroupsWithinProject(
     data?.project?.id
   );
+  const showPublishButton =
+    data &&
+    [
+      EventGroupEventsPublishStatusEnum.ReadyForFirstPublish,
+      EventGroupEventsPublishStatusEnum.ReadyForRepublish,
+    ].includes(publishStatus) &&
+    canPublish;
 
   return (
     <TopToolbar className={classes.toolbar}>
@@ -37,8 +47,17 @@ const EventGroupsDetailActions = ({ data, basePath, permissions }: any) => {
       {canManageEventGroups && (
         <EditButton basePath="/event-groups" record={data} />
       )}
-      {data && !isPublished && canPublish && (
-        <PublishEventGroupButton basePath={basePath} record={data} />
+      {showPublishButton && (
+        <PublishEventGroupButton
+          basePath={basePath}
+          record={data}
+          buttonLabel={
+            publishStatus ===
+            EventGroupEventsPublishStatusEnum.ReadyForRepublish
+              ? 'eventGroups.actions.publish.redo'
+              : 'eventGroups.actions.publish.do'
+          }
+        />
       )}
     </TopToolbar>
   );

--- a/src/domain/eventGroups/detail/EventReadyField.tsx
+++ b/src/domain/eventGroups/detail/EventReadyField.tsx
@@ -3,6 +3,7 @@ import { Record, useTranslate } from 'react-admin';
 import { makeStyles } from '@material-ui/core';
 import EditIcon from '@material-ui/icons/Edit';
 import CheckIcon from '@material-ui/icons/Check';
+import PublicIcon from '@material-ui/icons/Public';
 
 const useStyles = makeStyles((theme) => ({
   iconWithBackground: {
@@ -17,6 +18,9 @@ const useStyles = makeStyles((theme) => ({
     '&.is-ready': {
       backgroundColor: theme.palette.success.dark,
     },
+    '&.is-published': {
+      backgroundColor: theme.palette.info.dark,
+    },
   },
 }));
 
@@ -29,32 +33,45 @@ const EventReadyField = ({ record, className }: Props) => {
   const classes = useStyles();
   const t = useTranslate();
   const isReady = Boolean(record?.readyForEventGroupPublishing);
+  const isPublished = Boolean(record?.publishedAt);
   const classNames = [
     classes.iconWithBackground,
     isReady ? 'is-ready' : null,
+    isPublished ? 'is-published' : null,
     className,
   ]
     .filter(Boolean)
     .join(' ');
 
-  return (
-    <div className={classNames}>
-      {isReady && (
+  const getEventStatusIcon = () => {
+    if (isPublished) {
+      return (
+        <PublicIcon
+          style={{ fontSize: 14 }}
+          titleAccess={t('events.fields.ready.options.published')}
+          role="img"
+        />
+      );
+    } else if (isReady) {
+      return (
         <CheckIcon
           style={{ fontSize: 14 }}
           titleAccess={t('events.fields.ready.options.ready')}
           role="img"
         />
-      )}
-      {!isReady && (
+      );
+    } else {
+      return (
         <EditIcon
           style={{ fontSize: 14 }}
           titleAccess={t('events.fields.ready.options.notReady')}
           role="img"
         />
-      )}
-    </div>
-  );
+      );
+    }
+  };
+
+  return <div className={classNames}>{getEventStatusIcon()}</div>;
 };
 
 export default EventReadyField;

--- a/src/domain/eventGroups/detail/PublishEventGroupButton.tsx
+++ b/src/domain/eventGroups/detail/PublishEventGroupButton.tsx
@@ -13,9 +13,15 @@ type Props = {
   basePath: string;
   record: EvenGroup;
   className?: string;
+  buttonLabel?: string;
 };
 
-const PublishEventGroupButton = ({ basePath, record, className }: Props) => {
+const PublishEventGroupButton = ({
+  basePath,
+  record,
+  className,
+  buttonLabel = 'eventGroups.actions.publish.do',
+}: Props) => {
   const t = useTranslate();
 
   const handleErrorMessage = (error: Error) => {
@@ -32,7 +38,7 @@ const PublishEventGroupButton = ({ basePath, record, className }: Props) => {
     <ConfirmMutationButton
       basePath={basePath}
       className={className}
-      buttonLabel="eventGroups.actions.publish.do"
+      buttonLabel={buttonLabel}
       icon={<SendIcon />}
       successMessage="eventGroups.actions.publish.success"
       errorMessage={handleErrorMessage}

--- a/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
+++ b/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
@@ -42,6 +42,13 @@ describe('<EventGroupsDetailActions />', () => {
         project: {
           id: '123',
         },
+        publishedAt: null,
+        events: [
+          {
+            publishedAt: null,
+            readyForEventGroupPublishing: true,
+          },
+        ],
       },
       permissions: {
         canPublishWithinProject: () => true,
@@ -54,13 +61,57 @@ describe('<EventGroupsDetailActions />', () => {
     ).toBeTruthy();
   });
 
-  it('should hide publish button when the event group is already published', () => {
+  it('should hide publish button when the event group and its events are already published', () => {
     const { queryByRole } = getWrapper({
-      data: { publishedAt: new Date().toJSON() },
+      data: {
+        project: {
+          id: '123',
+        },
+        publishedAt: new Date().toJSON(),
+        events: [
+          {
+            publishedAt: new Date().toJSON(),
+            readyForEventGroupPublishing: true,
+          },
+        ],
+      },
+      permissions: {
+        canPublishWithinProject: () => true,
+        canManageEventGroupsWithinProject: () => true,
+      },
     });
 
     expect(
       queryByRole('button', { name: 'eventGroups.actions.publish.do' })
     ).toBeFalsy();
+  });
+
+  it('should render a republish button when there is a mix of unpublished and published event data', () => {
+    const { getByRole } = getWrapper({
+      data: {
+        project: {
+          id: '123',
+        },
+        publishedAt: new Date().toJSON(),
+        events: [
+          {
+            publishedAt: true,
+            readyForEventGroupPublishing: true,
+          },
+          {
+            publishedAt: null,
+            readyForEventGroupPublishing: true,
+          },
+        ],
+      },
+      permissions: {
+        canPublishWithinProject: () => true,
+        canManageEventGroupsWithinProject: () => true,
+      },
+    });
+
+    expect(
+      getByRole('button', { name: 'eventGroups.actions.publish.redo' })
+    ).toBeTruthy();
   });
 });

--- a/src/domain/eventGroups/detail/__tests__/EventReadyField.test.jsx
+++ b/src/domain/eventGroups/detail/__tests__/EventReadyField.test.jsx
@@ -8,13 +8,26 @@ const getWrapper = (props) =>
   render(<EventReadyField {...defaultProps} {...props} />);
 
 describe('<EventReadyField />', () => {
-  it('should render ready when event is marked as ready', () => {
+  it('should render ready when event is marked as ready but is not published yet', () => {
     const { getByRole } = getWrapper({
       record: { readyForEventGroupPublishing: true },
     });
 
     expect(
       getByRole('img', { name: 'events.fields.ready.options.ready' })
+    ).toBeTruthy();
+  });
+
+  it('should render ready when event is marked as ready and published', () => {
+    const { getByRole } = getWrapper({
+      record: {
+        readyForEventGroupPublishing: true,
+        publishedAt: new Date().toJSON(),
+      },
+    });
+
+    expect(
+      getByRole('img', { name: 'events.fields.ready.options.published' })
     ).toBeTruthy();
   });
 

--- a/src/domain/eventGroups/utils.ts
+++ b/src/domain/eventGroups/utils.ts
@@ -1,0 +1,33 @@
+import { EventGroup_eventGroup_events_edges_node as EventNode } from '../../api/generatedTypes/EventGroup';
+import { Record } from '../../api/types';
+
+export enum EventGroupEventsPublishStatusEnum {
+  NotReady = 'notReady',
+  ReadyForFirstPublish = 'readyForFirstPublish',
+  ReadyForRepublish = 'readyForRepublish',
+  AllPublished = 'allPublished',
+}
+
+export const isEveryEventPublished = (events: EventNode[]) => {
+  return events?.every((event) => event.publishedAt !== null) || false;
+};
+
+export const isEveryEventReadyForPublish = (events: EventNode[]) => {
+  return events?.every((event) => event.readyForEventGroupPublishing) || false;
+};
+
+export const getEventGroupPublishStatus = (eventGroup: Record | undefined) => {
+  if (eventGroup) {
+    if (isEveryEventPublished(eventGroup.events)) {
+      return EventGroupEventsPublishStatusEnum.AllPublished;
+    } else if (
+      !Boolean(eventGroup.publishedAt) &&
+      isEveryEventReadyForPublish(eventGroup.events)
+    ) {
+      return EventGroupEventsPublishStatusEnum.ReadyForFirstPublish;
+    } else if (isEveryEventReadyForPublish(eventGroup.events)) {
+      return EventGroupEventsPublishStatusEnum.ReadyForRepublish;
+    }
+  }
+  return EventGroupEventsPublishStatusEnum.NotReady;
+};


### PR DESCRIPTION
- Added event group republish features. KK-881 KK-884
- Added the event published status indicator to the EventGroup table. KK-881 KK-886. The green checkmark icon is to indicate the status of ready for publishment. The new blue earth icon is to indicate status of published event.

A new republish button (text) and a new (blue) status indicator for the published events:
<img width="934" alt="Screenshot 2022-03-31 at 9 38 24" src="https://user-images.githubusercontent.com/389204/161009400-22ae4e20-7dd4-40fa-918f-0248642f75d4.png">
<img width="943" alt="Screenshot 2022-03-31 at 9 38 45" src="https://user-images.githubusercontent.com/389204/161009407-ebe9cc57-6498-486b-b7f2-5d8faa2dbdb8.png">
<img width="926" alt="image" src="https://user-images.githubusercontent.com/389204/161009749-c89f762f-c54a-4b10-a5dd-b5f7c4ac11ce.png">

