### PR TITLE
KK-902 && KK-958 | Add passwords tab for Ticketmaster events

### DIFF
--- a/src/api/generatedTypes/Event.ts
+++ b/src/api/generatedTypes/Event.ts
@@ -58,9 +58,17 @@ export interface Event_event_project {
   myPermissions: Event_event_project_myPermissions | null;
 }
 
-export interface Event_event_ticketSystem {
+export interface Event_event_ticketSystem_InternalEventTicketSystem {
   type: TicketSystem;
 }
+
+export interface Event_event_ticketSystem_TicketmasterEventTicketSystem {
+  type: TicketSystem;
+  usedPasswordCount: number;
+  freePasswordCount: number;
+}
+
+export type Event_event_ticketSystem = Event_event_ticketSystem_InternalEventTicketSystem | Event_event_ticketSystem_TicketmasterEventTicketSystem;
 
 export interface Event_event {
   /**

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -500,6 +500,14 @@
     "error": "Ticket validation failed"
   },
   "ticketSystemPassword": {
+    "fields": {
+      "usedPasswordCount": {
+        "label": "Used Ticketmaster passwords"
+      },
+      "freePasswordCount": {
+        "label": "Free passwords"
+      }
+    },
     "import": {
       "dialog": {
         "openButton": "Add passwords",

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -500,6 +500,9 @@
     "error": "Ticket validation failed"
   },
   "ticketSystemPassword": {
+    "passwordsTab":{
+      "label": "Passwords"
+    },
     "fields": {
       "usedPasswordCount": {
         "label": "Used Ticketmaster passwords"

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -500,6 +500,9 @@
     "error": "Lipun tarkistaminen epäonnistui"
   },
   "ticketSystemPassword": {
+    "passwordsTab":{
+      "label": "Salasanat"
+    },
     "fields": {
       "usedPasswordCount": {
         "label": "Tapahtuman varatut Ticketmaster-salasanat"

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -500,6 +500,14 @@
     "error": "Lipun tarkistaminen epäonnistui"
   },
   "ticketSystemPassword": {
+    "fields": {
+      "usedPasswordCount": {
+        "label": "Tapahtuman varatut Ticketmaster-salasanat"
+      },
+      "freePasswordCount": {
+        "label": "Vapaat salasanat"
+      }
+    },
     "import": {
       "dialog": {
         "openButton": "Lisää salasanoja",

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -191,6 +191,14 @@ const EventShow = (props: ResourceComponentPropsWithId) => {
           <PublishedField locale={locale} />
         </Tab>
         <Tab label="events.fields.occurrences.label">
+          <NumberField
+            source="ticketSystem.usedPasswordCount"
+            label="ticketSystemPassword.fields.usedPasswordCount.label"
+          />
+          <NumberField
+            source="ticketSystem.freePasswordCount"
+            label="ticketSystemPassword.fields.freePasswordCount.label"
+          />
           {record && <OccurrenceTabHeaderControls record={record} />}
           <ReferenceManyField
             label=" "

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -16,7 +16,6 @@ import {
   ResourceComponentPropsWithId,
   Record,
   useShowController,
-  UrlField,
   FunctionField,
 } from 'react-admin';
 import { withStyles, WithStyles, createStyles } from '@material-ui/core/styles';
@@ -84,13 +83,13 @@ const ImportTicketSystemPasswordsButton = withStyles(styles)(
   }
 );
 
-interface OccurrenceTabHeaderControlsProps {
+interface ImportTicketmasterPasswordsControlsProps {
   record: AdminEvent;
 }
 
-const OccurrenceTabHeaderControls = ({
+const ImportTicketmasterPasswordsControls = ({
   record,
-}: OccurrenceTabHeaderControlsProps) => {
+}: ImportTicketmasterPasswordsControlsProps) => {
   const [isDialogShown, setShowDialog] = useState(false);
   const internalTicketSystem = hasInternalTicketSystem(record);
   return (
@@ -190,49 +189,36 @@ const EventShow = (props: ResourceComponentPropsWithId) => {
           )}
           <PublishedField locale={locale} />
         </Tab>
-        <Tab label="events.fields.occurrences.label">
-          <NumberField
-            source="ticketSystem.usedPasswordCount"
-            label="ticketSystemPassword.fields.usedPasswordCount.label"
-          />
-          <NumberField
-            source="ticketSystem.freePasswordCount"
-            label="ticketSystemPassword.fields.freePasswordCount.label"
-          />
-          {record && <OccurrenceTabHeaderControls record={record} />}
-          <ReferenceManyField
-            label=" "
-            reference="occurrences"
-            target="event_id"
-          >
-            <Datagrid rowClick="show">
-              <DateField
-                label="occurrences.fields.time.fields.date.label"
-                source="time"
-                locales={locale}
-              />
-              <OccurrenceTimeRangeField label="occurrences.fields.time.fields.time.label" />
-              <ReferenceField
-                label="occurrences.fields.venue.label"
-                source="venue.id"
-                reference="venues"
-                link={false}
-              >
-                <TextField source="translations.FI.name" />
-              </ReferenceField>
-              {internalTicketSystem && (
+        {internalTicketSystem ? (
+          <Tab label="events.fields.occurrences.label">
+            <ReferenceManyField
+              label=" "
+              reference="occurrences"
+              target="event_id"
+            >
+              <Datagrid rowClick="show">
+                <DateField
+                  label="occurrences.fields.time.fields.date.label"
+                  source="time"
+                  locales={locale}
+                />
+                <OccurrenceTimeRangeField label="occurrences.fields.time.fields.time.label" />
+                <ReferenceField
+                  label="occurrences.fields.venue.label"
+                  source="venue.id"
+                  reference="venues"
+                  link={false}
+                >
+                  <TextField source="translations.FI.name" />
+                </ReferenceField>
                 <NumberField
                   source="capacity"
                   label="occurrences.fields.capacity.label"
                 />
-              )}
-              {internalTicketSystem && (
                 <NumberField
                   source="enrolmentCount"
                   label="occurrences.fields.enrolmentsCount.label"
                 />
-              )}
-              {internalTicketSystem && (
                 <FunctionField
                   label="occurrences.fields.attendedEnrolmentsCount.label"
                   textAlign="right"
@@ -245,8 +231,6 @@ const EventShow = (props: ResourceComponentPropsWithId) => {
                     return attendedCount;
                   }}
                 />
-              )}
-              {internalTicketSystem && (
                 <FunctionField
                   label="occurrences.fields.freeSpotNotificationSubscriptions.label"
                   textAlign="right"
@@ -255,17 +239,23 @@ const EventShow = (props: ResourceComponentPropsWithId) => {
                     '?'
                   }
                 />
-              )}
-              {!internalTicketSystem && (
-                <UrlField
-                  source="ticketSystem.url"
-                  label="occurrences.fields.ticketSystemUrl.label"
-                />
-              )}
-            </Datagrid>
-          </ReferenceManyField>
-          <AddOccurrenceButton />
-        </Tab>
+              </Datagrid>
+            </ReferenceManyField>
+            <AddOccurrenceButton />
+          </Tab>
+        ) : (
+          <Tab label="ticketSystemPassword.passwordsTab.label">
+            <NumberField
+              source="ticketSystem.usedPasswordCount"
+              label="ticketSystemPassword.fields.usedPasswordCount.label"
+            />
+            <NumberField
+              source="ticketSystem.freePasswordCount"
+              label="ticketSystemPassword.fields.freePasswordCount.label"
+            />
+            {record && <ImportTicketmasterPasswordsControls record={record} />}
+          </Tab>
+        )}
       </TabbedShowLayout>
     </KukkuuDetailPage>
   );

--- a/src/domain/events/queries/EventQueries.ts
+++ b/src/domain/events/queries/EventQueries.ts
@@ -72,6 +72,10 @@ export const eventQuery = gql`
       }
       ticketSystem {
         type
+        ... on TicketmasterEventTicketSystem {
+          usedPasswordCount
+          freePasswordCount
+        }
       }
     }
   }

--- a/src/domain/ticketSystemPassword/ImportTicketSystemPasswordsFormDialog.tsx
+++ b/src/domain/ticketSystemPassword/ImportTicketSystemPasswordsFormDialog.tsx
@@ -7,7 +7,7 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Button from '@material-ui/core/Button';
 import TextareaAutosize from '@material-ui/core/TextareaAutosize';
-import { useNotify, useTranslate } from 'react-admin';
+import { useNotify, useTranslate, useRefresh } from 'react-admin';
 
 import ticketSystemPasswordsApi from './api/ticketSystemPasswordsApi';
 import { AdminEvent } from '../events/types/EventTypes';
@@ -35,6 +35,7 @@ const ImportTicketSystemPasswordsFormDialog = withStyles(styles)(
   }: ImportTicketSystemPasswordsModalProps) => {
     const translate = useTranslate();
     const [passwordsText, setPasswordsText] = React.useState('');
+    const refresh = useRefresh();
     const notify = useNotify();
     const onChangePasswordsText: React.ChangeEventHandler<HTMLTextAreaElement> = (
       e
@@ -82,6 +83,8 @@ const ImportTicketSystemPasswordsFormDialog = withStyles(styles)(
 
       // Close the dialog
       onClose();
+
+      refresh();
     };
 
     return (


### PR DESCRIPTION
In the future Ticketmaster events cannot have occurrences, so for them "occurrences" tab is replaced with "passwords" tab which contains the password counts and the import button. The passwords tab contains counts of used and free passwords, and the button to import new passwords.

<img width="629" alt="Screenshot 2022-09-30 at 11 44 06" src="https://user-images.githubusercontent.com/1314604/193230723-466aad79-aa13-4748-b444-f68ed7d23781.png">
