### PR TITLE
KK-972 | Add ticketmaster event end time

### DIFF
--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -168,6 +168,10 @@
           }
         }
       },
+      "ticketSystemEndTime": {
+        "label": "End time",
+        "helperText": "After this time, the event will be removed from event invites and upcoming events."
+      },
       "ticketSystemUrl": {
         "label": "The event's URL address in the external ticket system"
       },

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -168,6 +168,10 @@
           }
         }
       },
+      "ticketSystemEndTime": {
+        "label": "Loppuaika",
+        "helperText": "Tämän ajankohdan jälkeen tapahtuma poistuu tapahtumakutsuista ja tulevista tapahtumista."
+      },
       "ticketSystemUrl": {
         "label": "Tapahtuman URL-osoite lippujärjestelmässä"
       }

--- a/src/domain/events/api/EventApi.ts
+++ b/src/domain/events/api/EventApi.ts
@@ -43,8 +43,12 @@ const addEvent: MethodHandler = async (params: MethodHandlerParams) => {
     data.image = params.data.image.rawFile;
   }
 
-  if (!hasInternalTicketSystem(data)) {
-    data.capacityPerOccurrence = null;
+  if (hasInternalTicketSystem(data)) {
+    delete data.ticketSystem.url;
+    delete data.ticketSystem.endTime;
+  } else {
+    delete data.capacityPerOccurrence;
+    delete data.duration;
   }
 
   const response = await mutationHandler({
@@ -64,6 +68,7 @@ const updateEvent: MethodHandler = async (params: MethodHandlerParams) => {
     'translations',
     'readyForEventGroupPublishing',
     'ticketSystem.url',
+    'ticketSystem.endTime',
   ]);
   const data = mapLocalDataToApiData(localUpdateData);
 
@@ -73,8 +78,14 @@ const updateEvent: MethodHandler = async (params: MethodHandlerParams) => {
     data.image = '';
   }
 
-  if (!hasInternalTicketSystem(data)) {
-    data.capacityPerOccurrence = null;
+  if (hasInternalTicketSystem(params.data)) {
+    if (data.ticketSystem) {
+      delete data.ticketSystem.url;
+      delete data.ticketSystem.endTime;
+    }
+  } else {
+    delete data.capacityPerOccurrence;
+    delete data.duration;
   }
 
   const response = await mutationHandler({

--- a/src/domain/events/create/EventCreate.tsx
+++ b/src/domain/events/create/EventCreate.tsx
@@ -8,6 +8,7 @@ import {
   useTranslate,
   ReactAdminComponentProps,
   FormDataConsumer,
+  DateTimeInput,
 } from 'react-admin';
 
 import {
@@ -128,37 +129,53 @@ const EventCreate = (props: ReactAdminComponentProps) => {
         )}
         <FormDataConsumer>
           {({ formData, ...rest }) =>
-            hasInternalTicketSystem(formData) ? (
-              <NumberInput
-                source="capacityPerOccurrence"
-                label="events.fields.capacityPerOccurrence.label"
-                helperText="events.fields.capacityPerOccurrence.helperText"
-                validate={validateCapacityPerOccurrence}
-                style={{ width: '100%' }}
-                {...rest}
-                // aria-describedby should be set automatically but it is not.
-                // Seems like a bug related to FormDataConsumer.
-                aria-describedby="capacityPerOccurrence-helper-text"
-                id="capacityPerOccurrence"
-              />
-            ) : (
-              <TextInput
-                source="ticketSystem.url"
-                label="events.fields.ticketSystemUrl.label"
-                validate={validateUrl}
-                style={{ width: '100%' }}
-                {...rest}
-              />
-            )
+            hasInternalTicketSystem(formData)
+              ? [
+                  <NumberInput
+                    source="duration"
+                    key="duration"
+                    label="events.fields.duration.label"
+                    helperText="events.fields.duration.helperText"
+                    validate={validateDuration}
+                    style={{ width: '100%' }}
+                    {...rest}
+                  />,
+                  <NumberInput
+                    source="capacityPerOccurrence"
+                    key="capacityPerOccurrence"
+                    label="events.fields.capacityPerOccurrence.label"
+                    helperText="events.fields.capacityPerOccurrence.helperText"
+                    validate={validateCapacityPerOccurrence}
+                    style={{ width: '100%' }}
+                    {...rest}
+                    // aria-describedby should be set automatically but it is not.
+                    // Seems like a bug related to FormDataConsumer.
+                    aria-describedby="capacityPerOccurrence-helper-text"
+                    id="capacityPerOccurrence"
+                  />,
+                ]
+              : [
+                  <TextInput
+                    source="ticketSystem.url"
+                    key="ticketSystemUrl"
+                    label="events.fields.ticketSystemUrl.label"
+                    validate={validateUrl}
+                    style={{ width: '100%' }}
+                    {...rest}
+                  />,
+                  <DateTimeInput
+                    source="ticketSystem.endTime"
+                    key="ticketSystemEndTime"
+                    label="events.fields.ticketSystemEndTime.label"
+                    helperText="events.fields.ticketSystemEndTime.helperText"
+                    style={{ width: '100%' }}
+                    {...rest}
+                    aria-describedby="ticketSystemEndTime-helper-text"
+                    id="ticketSystemEndTime"
+                  />,
+                ]
           }
         </FormDataConsumer>
-        <NumberInput
-          source="duration"
-          label="events.fields.duration.label"
-          helperText="events.fields.duration.helperText"
-          validate={validateDuration}
-          fullWidth
-        />
       </SimpleForm>
     </KukkuuCreatePage>
   );

--- a/src/domain/events/detail/EventShow.tsx
+++ b/src/domain/events/detail/EventShow.tsx
@@ -172,30 +172,39 @@ const EventShow = (props: ResourceComponentPropsWithId) => {
             label={'events.fields.participantsPerInvite.label'}
             choices={participantsPerInviteChoices}
           />
-          <NumberField
-            source={`duration`}
-            label={'events.fields.duration.label'}
-          />
-          {internalTicketSystem ? (
-            <NumberField
-              source="capacityPerOccurrence"
-              label="events.fields.capacityPerOccurrence.label"
-            />
-          ) : (
-            [
-              <SelectField
-                source="ticketSystem.type"
-                label="events.fields.ticketSystem.label"
-                choices={ticketSystemChoices}
-                key="externalTicketSystemField1"
-              />,
-              <UrlField
-                source="ticketSystem.url"
-                label="events.fields.ticketSystemUrl.label"
-                key="externalTicketSystemField2"
-              />,
-            ]
-          )}
+          {internalTicketSystem
+            ? [
+                <NumberField
+                  source="duration"
+                  key="duration"
+                  label="events.fields.duration.label"
+                />,
+                <NumberField
+                  source="capacityPerOccurrence"
+                  key="capacityPerOccurrence"
+                  label="events.fields.capacityPerOccurrence.label"
+                />,
+              ]
+            : [
+                <SelectField
+                  source="ticketSystem.type"
+                  label="events.fields.ticketSystem.label"
+                  choices={ticketSystemChoices}
+                  key="ticketSystemType"
+                />,
+                <UrlField
+                  source="ticketSystem.url"
+                  label="events.fields.ticketSystemUrl.label"
+                  key="ticketSystemUrl"
+                />,
+                <DateField
+                  source="ticketSystem.endTime"
+                  label="events.fields.ticketSystemEndTime.label"
+                  key="ticketSystemEndTime"
+                  showTime={true}
+                  locales={locale}
+                />,
+              ]}
           <PublishedField locale={locale} />
         </Tab>
         {internalTicketSystem ? (

--- a/src/domain/events/edit/EventEdit.tsx
+++ b/src/domain/events/edit/EventEdit.tsx
@@ -10,6 +10,7 @@ import {
   DeleteButton,
   useTranslate,
   FormDataConsumer,
+  DateTimeInput,
 } from 'react-admin';
 import { CardHeader, Grid } from '@material-ui/core';
 
@@ -128,37 +129,54 @@ const EventEdit = (props: any) => {
             )}
             <FormDataConsumer>
               {({ formData, ...rest }) =>
-                hasInternalTicketSystem(formData) ? (
-                  <NumberInput
-                    source="capacityPerOccurrence"
-                    label="events.fields.capacityPerOccurrence.label"
-                    helperText="events.fields.capacityPerOccurrence.helperText"
-                    validate={validateCapacityPerOccurrence}
-                    style={{ width: '100%' }}
-                    {...rest}
-                    // aria-describedby should be set automatically but it is not.
-                    // Seems like a bug related to FormDataConsumer.
-                    aria-describedby="capacityPerOccurrence-helper-text"
-                    id="capacityPerOccurrence"
-                  />
-                ) : (
-                  <TextInput
-                    source="ticketSystem.url"
-                    label="events.fields.ticketSystemUrl.label"
-                    validate={validateUrl}
-                    style={{ width: '100%' }}
-                    {...rest}
-                  />
-                )
+                // TODO this part is exactly the same as in EventCreate so there could be a common component for both
+                hasInternalTicketSystem(formData)
+                  ? [
+                      <NumberInput
+                        source="duration"
+                        key="duration"
+                        label="events.fields.duration.label"
+                        helperText="events.fields.duration.helperText"
+                        validate={validateDuration}
+                        style={{ width: '100%' }}
+                        {...rest}
+                      />,
+                      <NumberInput
+                        source="capacityPerOccurrence"
+                        key="capacityPerOccurrence"
+                        label="events.fields.capacityPerOccurrence.label"
+                        helperText="events.fields.capacityPerOccurrence.helperText"
+                        validate={validateCapacityPerOccurrence}
+                        style={{ width: '100%' }}
+                        {...rest}
+                        // aria-describedby should be set automatically but it is not.
+                        // Seems like a bug related to FormDataConsumer.
+                        aria-describedby="capacityPerOccurrence-helper-text"
+                        id="capacityPerOccurrence"
+                      />,
+                    ]
+                  : [
+                      <TextInput
+                        source="ticketSystem.url"
+                        key="ticketSystemUrl"
+                        label="events.fields.ticketSystemUrl.label"
+                        validate={validateUrl}
+                        style={{ width: '100%' }}
+                        {...rest}
+                      />,
+                      <DateTimeInput
+                        source="ticketSystem.endTime"
+                        key="ticketSystemEndTime"
+                        label="events.fields.ticketSystemEndTime.label"
+                        helperText="events.fields.ticketSystemEndTime.helperText"
+                        style={{ width: '100%' }}
+                        {...rest}
+                        aria-describedby="ticketSystemEndTime-helper-text"
+                        id="ticketSystemEndTime"
+                      />,
+                    ]
               }
             </FormDataConsumer>
-            <NumberInput
-              source="duration"
-              label="events.fields.duration.label"
-              helperText="events.fields.duration.helperText"
-              validate={validateDuration}
-              fullWidth
-            />
           </SimpleForm>
         </KukkuuEdit>
       </Grid>

--- a/src/domain/events/edit/EventEdit.tsx
+++ b/src/domain/events/edit/EventEdit.tsx
@@ -125,6 +125,7 @@ const EventEdit = (props: any) => {
                 label="events.fields.ticketSystem.label"
                 choices={ticketSystemChoices}
                 fullWidth
+                disabled
               />
             )}
             <FormDataConsumer>

--- a/src/domain/events/mutations/EventMutations.ts
+++ b/src/domain/events/mutations/EventMutations.ts
@@ -13,6 +13,7 @@ export const addEventMutation = gql`
           type
           ... on TicketmasterEventTicketSystem {
             url
+            endTime
           }
         }
         translations {
@@ -55,6 +56,7 @@ export const updateEventMutation = gql`
           type
           ... on TicketmasterEventTicketSystem {
             url
+            endTime
           }
         }
       }

--- a/src/domain/events/queries/EventQueries.ts
+++ b/src/domain/events/queries/EventQueries.ts
@@ -30,6 +30,7 @@ export const eventsQuery = gql`
             type
             ... on TicketmasterEventTicketSystem {
               url
+              endTime
             }
           }
         }
@@ -79,6 +80,7 @@ export const eventQuery = gql`
           usedPasswordCount
           freePasswordCount
           url
+          endTime
         }
       }
     }


### PR DESCRIPTION
## Description

Added event end time field which is shown and used only with external ticket system events. Also changed event duration field to be used only with external ticket system events.

One browser test is failing but that is an old issue unrelated to this PR.

## Context

[KK-972](https://helsinkisolutionoffice.atlassian.net/browse/KK-972)
