### PR TITLE
ci: add version and release information in the (Nginx) readiness probe

### DIFF
--- a/.prod/nginx.conf.template
+++ b/.prod/nginx.conf.template
@@ -1,3 +1,9 @@
+### nginx.conf.template -- The following environment variables should be set by the Dockerfile.
+# - APP_VERSION
+# - REACT_APP_BUILDTIME
+# - REACT_APP_RELEASE
+# - REACT_APP_COMMITHASH
+###
 server {
     listen       8080;
     server_name  localhost;
@@ -9,7 +15,8 @@ server {
     }
 
     location /readiness {
-        return 200 'OK';
+        default_type application/json;
+        return 200 '{ "status": "ok", "release": "${REACT_APP_RELEASE}", "packageVersion": "${APP_VERSION}", "commitHash": "${REACT_APP_COMMITHASH}", "buildTime": "${REACT_APP_BUILDTIME}" }';
     }
 
     location /static {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.11.1",
   "private": true,
   "scripts": {
+    "app:version": "echo \"$npm_package_version\"",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "typecheck": "tsc",


### PR DESCRIPTION
KK-1002 KK-1046

Read the following environment variables that are set in the pipeline process and set them in the respond of the Nginx /readiness -probe:
- RELEASE
- APP_VERSION
- COMMITHASH
- BUILD_TIME
----
The same change in the Kukkuu UI: https://github.com/City-of-Helsinki/kukkuu-ui/pull/501.
The pipeline changes: https://dev.azure.com/City-of-Helsinki/kukkuu/_git/kukkuu-pipelines/pullrequest/6470
