### PR TITLE
fix(messages): recipient selection validation after change

### DIFF
--- a/src/domain/messages/form/MessageForm.tsx
+++ b/src/domain/messages/form/MessageForm.tsx
@@ -97,17 +97,15 @@ const MessageForm = ({ protocol, ...delegatedProps }: Props) => {
     event: ChangeEvent<HTMLInputElement>,
     form: ReturnType<typeof useFormContext>
   ) => {
-    const value = event?.target.value;
+    const recipients = event?.target.value;
     const name = event?.target.name;
 
-    // When the user sets recipient as all, event and occurrence
-    // choices are reset
-    if (value === 'ALL') {
+    if (['ALL', 'INVITED'].includes(recipients)) {
       form.setValue('eventId', 'all');
       form.setValue('occurrenceIds', ['all']);
     }
 
-    form.setValue(name, value);
+    form.setValue(name, recipients);
   };
 
   const handleEvenIdChange = (


### PR DESCRIPTION
KK-1054.
When a recipient was changed from some event specific selection to "invited", the event fields were not cleared. Because of that, the validation didn't pass, because it had too many fields filled.

The "invited" option is now handled the same as the "all" when the recipient is changed.

----

Steps to reproduce:

1. Fill the form with some event specific data
<img width="975" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-admin/assets/389204/6296fc31-1fba-42a0-9205-ba44db46d240">
2. Change the recipient to "invited" <img width="688" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-admin/assets/389204/f4befa80-8ff0-4902-9046-b3ea1d7fab39">

The result: there should be no validation error anymore.