### PR TITLE
feat(event-form): fields can be normalized in a transform before form save

### DIFF
--- a/src/common/__tests__/utils.test.js
+++ b/src/common/__tests__/utils.test.js
@@ -1,3 +1,5 @@
+import set from 'lodash/set';
+
 import {
   sum,
   requireFinnishFields,
@@ -5,6 +7,8 @@ import {
   toShortDateTimeString,
   toDateString,
   toTimeString,
+  getNormalizedValues,
+  createTranslationObject,
 } from '../utils';
 
 describe('common utils', () => {
@@ -83,5 +87,167 @@ describe('common utils', () => {
         expect(formatter(date)).toMatchSnapshot();
       });
     });
+  });
+
+  describe('getNormalizedValues', () => {
+    const fieldNormalizerMap = {
+      nullToEmptyStringField: [[null], ''],
+      zeroToNullField: [[0], null],
+      falthyValuesToFalseField: [[0, '', null], false],
+      'nestedField.x': [[0], false],
+      'nestedField.y': [[1], true],
+      'nestedField.translations.fi': [[null], ''],
+      'nestedField.translations.sv': [[null], ''],
+      'nestedField.translations.en': [[null], ''],
+    };
+
+    const getAllCases = (fieldNormalizerMap) =>
+      Object.entries(fieldNormalizerMap)
+        .map(([fieldName, [sourceValues, normalizedValue]]) =>
+          sourceValues.map((sourceValue) => [
+            fieldName,
+            sourceValue,
+            normalizedValue,
+          ])
+        )
+        .flat();
+
+    it.each(getAllCases(fieldNormalizerMap))(
+      'normalizes field `%s` from value `%s` to a value `%s`',
+      async (field, sourceValue, normalizedValue) => {
+        const formValues = set({}, field, sourceValue);
+        const expectedValues = set({}, field, normalizedValue);
+        const normalizedValues = getNormalizedValues({
+          fieldNormalizerMap,
+          formValues,
+        });
+        expect(normalizedValues).toStrictEqual(expectedValues);
+      }
+    );
+
+    it('only manipulates the fields that are included in the `fieldNormalizerMap`', async () => {
+      const formValues = { nullToEmptyStringField: null, zeroToNullField: 0 };
+      const normalizedValues = getNormalizedValues({
+        fieldNormalizerMap,
+        formValues,
+      });
+      expect(normalizedValues).toStrictEqual({
+        nullToEmptyStringField: '',
+        zeroToNullField: null,
+      });
+    });
+
+    it('returns only the fields that that should be transformed if the initialValues is not given', async () => {
+      const formValues = {
+        nullToEmptyStringField: null,
+        zeroToNullField: 0,
+        a: 1,
+        b: 2,
+      };
+      const normalizedValues = getNormalizedValues({
+        fieldNormalizerMap,
+        formValues,
+      });
+      expect(normalizedValues).toStrictEqual({
+        nullToEmptyStringField: '',
+        zeroToNullField: null,
+      });
+    });
+
+    it('uses the initial values as a base for returned formValues', async () => {
+      const formValues = {
+        nullToEmptyStringField: null,
+        zeroToNullField: 0,
+        a: 1,
+        b: 2,
+      };
+      const normalizedValues = getNormalizedValues({
+        fieldNormalizerMap,
+        formValues,
+        initialValues: formValues,
+      });
+      expect(normalizedValues).toStrictEqual({
+        nullToEmptyStringField: '',
+        zeroToNullField: null,
+        a: 1,
+        b: 2,
+      });
+    });
+
+    it('handles the nested fields', async () => {
+      const formValues = {
+        zeroToNullField: 0,
+        nestedField: {
+          x: 0,
+          y: 1,
+          translations: {
+            fi: null,
+            en: null,
+            sv: null,
+          },
+        },
+      };
+      const normalizedValues = getNormalizedValues({
+        fieldNormalizerMap,
+        formValues,
+      });
+      expect(normalizedValues).toStrictEqual({
+        zeroToNullField: null,
+        nestedField: {
+          x: false,
+          y: true,
+          translations: {
+            fi: '',
+            en: '',
+            sv: '',
+          },
+        },
+      });
+    });
+  });
+
+  describe('createTranslationObject', () => {
+    it.each([
+      [['a', 'b', 'c'], 'translations', ''],
+      [['x', 'y', 'z'], 'root', null],
+    ])(
+      'creates a translation object for fields `%s` under the key `%s` with init value `%s`',
+      async (fields, translationProperty, initValue) => {
+        const dictionary = createTranslationObject({
+          translatableFields: fields,
+          translationsKeyName: translationProperty,
+          value: initValue,
+          flattenedWithDotNotation: false,
+        });
+        fields.forEach((field) => {
+          ['FI', 'SV', 'EN'].forEach((lang) => {
+            expect(dictionary[translationProperty][lang][field]).toStrictEqual(
+              initValue
+            );
+          });
+        });
+      }
+    );
+    it.each([
+      [['a', 'b', 'c'], 'translations', ''],
+      [['x', 'y', 'z'], 'root', null],
+    ])(
+      'creates a flattened, dot notated, translation object for fields `%s` under the key `%s` with init value `%s`',
+      async (fields, translationProperty, initValue) => {
+        const dictionary = createTranslationObject({
+          translatableFields: fields,
+          translationsKeyName: translationProperty,
+          value: initValue,
+          flattenedWithDotNotation: true,
+        });
+        fields.forEach((field) => {
+          ['FI', 'SV', 'EN'].forEach((lang) => {
+            expect(
+              dictionary[`${translationProperty}.${lang}.${field}`]
+            ).toStrictEqual(initValue);
+          });
+        });
+      }
+    );
   });
 });

--- a/src/common/providers/TranslatableProvider.tsx
+++ b/src/common/providers/TranslatableProvider.tsx
@@ -39,7 +39,7 @@ export default function TranslatableProvider({
     selector,
   };
 
-  const uniqueKeyForLanguageConteiner = `translatable-context${
+  const uniqueKeyForLanguageContainer = `translatable-context${
     groupKey ? '-' + groupKey : ''
   }-${selectedLanguage}`;
 
@@ -48,7 +48,7 @@ export default function TranslatableProvider({
       {/* NOTE: The fields won't unmount without a container with a key-parameter 
       (or key in each field), so without the changing container, 
       the fields values won't be refreshed when the language is changed. */}
-      <div key={uniqueKeyForLanguageConteiner}>{children}</div>
+      <div key={uniqueKeyForLanguageContainer}>{children}</div>
     </TranslatableContext.Provider>
   );
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,1 +1,9 @@
+import type { FieldValues } from 'react-hook-form';
+
 export type ContentLanguage = 'FI' | 'SV' | 'EN';
+
+export type ValuesToNormalize = any[];
+export type NormalizedValue = any;
+export type FormFieldValueNormalizer<T extends FieldValues> = {
+  [fieldName in keyof T]: [ValuesToNormalize, NormalizedValue];
+};

--- a/src/domain/events/create/EventCreate.tsx
+++ b/src/domain/events/create/EventCreate.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { useTranslate } from 'react-admin';
 import { useLocation } from 'react-router-dom';
+import type { FieldValues } from 'react-hook-form';
 
 import Aside from '../../../common/components/aside/Aside';
 import KukkuuCreatePage from '../../application/layout/kukkuuCreatePage/KukkuuCreatePage';
 import EventForm from '../eventForm/EventForm';
+import {
+  createTranslationObject,
+  getNormalizedValues,
+} from '../../../common/utils';
+import { FormFieldValueNormalizer } from '../../../common/types';
 
 const EventCreate = () => {
   const { search } = useLocation();
@@ -12,8 +18,23 @@ const EventCreate = () => {
   const translate = useTranslate();
 
   const transform = (data: any) => {
+    const fieldNormalizerMap = createTranslationObject({
+      translatableFields: [
+        'imageAltText',
+        'name',
+        'shortDescription',
+        'description',
+      ],
+      translationsKeyName: 'translations',
+      value: [[null], ''],
+      flattenedWithDotNotation: true,
+    }) as FormFieldValueNormalizer<FieldValues>;
     return {
-      ...data,
+      ...getNormalizedValues({
+        fieldNormalizerMap,
+        formValues: data,
+        initialValues: data,
+      }),
       eventGroupId,
     };
   };

--- a/src/domain/events/edit/EventEdit.tsx
+++ b/src/domain/events/edit/EventEdit.tsx
@@ -1,13 +1,37 @@
 import React from 'react';
 import { useTranslate } from 'react-admin';
 import { CardHeader, Grid } from '@mui/material';
+import type { FieldValues } from 'react-hook-form';
 
 import KukkuuEdit from '../../application/layout/kukkuuEditPage/KukkuuEdit';
 import ViewTitle from '../../../common/components/viewTitle/ViewTitle';
 import EventForm from '../eventForm/EventForm';
+import {
+  createTranslationObject,
+  getNormalizedValues,
+} from '../../../common/utils';
+import { FormFieldValueNormalizer } from '../../../common/types';
 
 const EventEdit = () => {
   const translate = useTranslate();
+  const transform = (data: any) => {
+    const fieldNormalizerMap = createTranslationObject({
+      translatableFields: [
+        'imageAltText',
+        'name',
+        'shortDescription',
+        'description',
+      ],
+      translationsKeyName: 'translations',
+      value: [[null], ''],
+      flattenedWithDotNotation: true,
+    }) as FormFieldValueNormalizer<FieldValues>;
+    return getNormalizedValues({
+      fieldNormalizerMap,
+      formValues: data,
+      initialValues: data,
+    });
+  };
 
   // Undoable / mutationMode is false to prevent image from appearing while waiting for backend result.
   return (
@@ -18,6 +42,7 @@ const EventEdit = () => {
           mutationMode={'pessimistic'}
           title={'events.edit.title'}
           redirect="show"
+          transform={transform}
         >
           <ViewTitle />
           <EventForm view="edit" />

--- a/src/domain/events/eventForm/EventForm.tsx
+++ b/src/domain/events/eventForm/EventForm.tsx
@@ -32,6 +32,7 @@ import TranslatableProvider from '../../../common/providers/TranslatableProvider
 
 const EventForm = ({ view }: { view: 'create' | 'edit' }) => {
   const isEditing = view === 'edit';
+
   return (
     <SimpleForm
       // TODO: refactor form validate with YUP


### PR DESCRIPTION
LIIKUNTA-594.
The `null`-values are not accepted by the API. 

When a translation object field is cleared, it is stored as `null` in the form context. With the new utilities, it's easier to transform nulls to empty strings. The tools can be used transform for any value .


Steps to reproduce:
1. Fill an event form field
2. Clear the value from the input
3. Save
Result: Earlier this couldn't be done because the API raised a constraint exception.

NOTE: This is still a draft, since there could be a fix made also in the API.