### PR TITLE
fix: transform nulls to empty strings when sending data to the API

### DIFF
--- a/src/api/utils/apiUtils.ts
+++ b/src/api/utils/apiUtils.ts
@@ -4,6 +4,7 @@ import {
   MutationOptions,
 } from '@apollo/client';
 import { HttpError } from 'react-admin';
+import mapValues from 'lodash/mapValues';
 
 import client from '../apolloClient/client';
 import { API_ERROR_MESSAGE } from '../constants/ApiConstants';
@@ -81,8 +82,13 @@ export const denormalizeLocalTranslations = <T>(
   adminTranslations: AdminUITranslation<T>
 ) => {
   const apiTranslations: T[] = [];
-  for (const [k, v] of Object.entries(adminTranslations)) {
-    apiTranslations.push(Object.assign({ languageCode: k }, v));
+  for (const [languageCode, translationEntry] of Object.entries(
+    adminTranslations
+  )) {
+    const normalizedData = mapValues(translationEntry as object, (v) =>
+      v === null ? '' : v
+    );
+    apiTranslations.push({ languageCode, ...normalizedData } as T);
   }
   return apiTranslations;
 };


### PR DESCRIPTION
LIIKUNTA-594.
The null-values are not accepted by the API when dealing with translation objects.

When a translation object field is cleared, it is stored as null in the form context. With the new utilities, it's easier to transform nulls to empty strings. The tools can be used transform for any value .

Steps to reproduce:

Fill an event form field
Clear the value from the input
Save
Result: Earlier this couldn't be done because the API raised a constraint exception.