### PR TITLE
fix(messages): recipient count in the send email modal window

### DIFF
--- a/src/domain/messages/detail/MessageDetailsToolbar.tsx
+++ b/src/domain/messages/detail/MessageDetailsToolbar.tsx
@@ -61,11 +61,7 @@ const MessageDetailToolbar = () => {
     <TopToolbar>
       {record && <EditButton record={record} />}
       {record && basePath && (
-        <MessageSendButton
-          basePath={basePath}
-          record={record}
-          className={classes.sendButton}
-        />
+        <MessageSendButton className={classes.sendButton} />
       )}
     </TopToolbar>
   );

--- a/src/domain/messages/detail/MessageSendButton.tsx
+++ b/src/domain/messages/detail/MessageSendButton.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { useTranslate } from 'react-admin';
+import {
+  useRecordContext,
+  useResourceContext,
+  useTranslate,
+} from 'react-admin';
 import SendIcon from '@mui/icons-material/Check';
 
 import { Message_message as Message } from '../../../api/generatedTypes/Message';
@@ -7,14 +11,13 @@ import ConfirmMutationButton from '../../../common/components/confirmMutationBut
 import useMessageSendMutation from '../hooks/useMessageSendMutation';
 
 type Props = {
-  /** @deprecated - create with useResourceContext instead. */
-  basePath: string;
-  /** @deprecated - create with useRecordContext instead. */
-  record: Message;
   className?: string;
 };
 
-const MessagesSendButton = ({ basePath, record, className }: Props) => {
+const MessagesSendButton = ({ className }: Props) => {
+  const record = useRecordContext<Message>();
+  const resource = useResourceContext();
+  const basePath = `/${resource}`;
   const t = useTranslate();
   const mutation = useMessageSendMutation({
     basePath,
@@ -32,7 +35,7 @@ const MessagesSendButton = ({ basePath, record, className }: Props) => {
         }),
         content: 'messages.send.confirm.content',
         translateOptions: {
-          recipientCount: record?.recipientCount || '?',
+          recipientCount: record?.recipientCount ?? '?',
         },
       }}
     />


### PR DESCRIPTION
KK-1051.
The email message recipient count was not shown properly in the message sending modal window when there were 0 recipients.

Some of the messages are in a scope of 0 recipients:
<img width="1343" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-admin/assets/389204/fc332bfe-1da9-4810-b3c3-779e9dd2b229">

When a message sending modal is opened, instead of showing `0`, a `?` was shown instead. Now it's fixed:

<img width="1548" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-admin/assets/389204/5f994c56-0de5-4b61-8542-47c540ba7af1">

If there would be more recipients, it would be shown:

<img width="1547" alt="image" src="https://github.com/City-of-Helsinki/kukkuu-admin/assets/389204/256369b4-8393-4ede-b7ad-12af993e4594">

