### PR TITLE
fix: remove the broken birthyear column from occurrence page

### DIFF
--- a/src/domain/occurrences/OccurrenceShow.tsx
+++ b/src/domain/occurrences/OccurrenceShow.tsx
@@ -153,11 +153,6 @@ const OccurrenceShow = () => {
               label="children.fields.name.label"
               render={withEnrolment(getChildFullName, () => null)}
             />
-            <DateField
-              source="node.child.birthyear"
-              label="children.fields.birthyear.label"
-              locales={locale}
-            />
             <FunctionField
               render={withEnrolment(
                 withGuardian(getGuardianFullName, () =>


### PR DESCRIPTION
KK-1080.

The column was broken on occurrence page after birthdate to birthyear changes:
![image](https://github.com/City-of-Helsinki/kukkuu-admin/assets/389204/088ba45e-963e-41ca-a703-264a300f1193)

Since all the kids have the same value (same year) in the column, the product owner requested for removal of the column:
![image](https://github.com/City-of-Helsinki/kukkuu-admin/assets/389204/653eec1e-bb8a-4046-8226-064655f489e3)

