### PR TITLE
fix: occurrence creation and edit view

### DIFF
--- a/src/domain/occurrences/OccurrenceCreate.tsx
+++ b/src/domain/occurrences/OccurrenceCreate.tsx
@@ -4,7 +4,6 @@ import {
   SimpleForm,
   SelectInput,
   ReferenceInput,
-  required,
   Loading,
 } from 'react-admin';
 import Grid from '@mui/material/Grid';
@@ -26,10 +25,11 @@ const OccurrenceCreateForm = () => {
         label="occurrences.fields.venue.label"
         source="venueId"
         reference="venues"
-        validate={[required()]}
+        isRequired
         fullWidth
       >
         <SelectInput
+          required
           variant="outlined"
           optionText="translations.FI.name"
           helperText="occurrences.fields.venue.helperText"

--- a/src/domain/occurrences/OccurrenceEdit.tsx
+++ b/src/domain/occurrences/OccurrenceEdit.tsx
@@ -4,7 +4,6 @@ import {
   SimpleForm,
   SelectInput,
   ReferenceInput,
-  required,
   Toolbar,
   SaveButton,
   DeleteButton,
@@ -75,10 +74,11 @@ const OccurrenceEditForm = () => {
         label="occurrences.fields.venue.label"
         source="venue.id"
         reference="venues"
-        validate={[required()]}
+        isRequired
         fullWidth
       >
         <SelectInput
+          required
           variant="outlined"
           optionText="translations.FI.name"
           helperText="occurrences.fields.venue.helperText"


### PR DESCRIPTION
KK-1049.

The React-admin plugin has a special handling for validation in the useInput-hook. That is there to prevent handling the translations to be handled twice -- once by React-admin and once by the input functions I suppose. To fix the translation of the validation error message, a special handler was needed to be used with the BoundedTextField.

Also, the occurrence edit and create views were broken, because the validation function was set as a property for a ReferenceInput (of React-admin), which no longer has such a property.

<img width="1097" alt="Screenshot 2024-03-13 at 16 48 06" src="https://github.com/City-of-Helsinki/kukkuu-admin/assets/389204/f4b6d393-2b76-47bf-b717-d8a284ccec5e">

