### PR TITLE
KK-1156 | Add silent token refreshing with Keycloak

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,16 @@
+PORT=3001
+REACT_APP_OIDC_AUDIENCES=kukkuu-api-test
+REACT_APP_OIDC_AUTHORITY=https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/
+REACT_APP_OIDC_CLIENT_ID=kukkuu-admin-ui-test
+REACT_APP_OIDC_KUKKUU_API_CLIENT_ID=kukkuu-api-test
+REACT_APP_OIDC_RETURN_TYPE=code
+REACT_APP_OIDC_SCOPE="openid profile email"
+REACT_APP_OIDC_SERVER_TYPE=KEYCLOAK
+REACT_APP_KUKKUU_API_OIDC_SCOPE=https://api.hel.fi/auth/kukkuu
+REACT_APP_API_URI=https://kukkuu.api.test.hel.ninja/graphql
+REACT_APP_SENTRY_DSN=https://c89ee3f57dc94ffd940d1df1a353b97f@sentry.hel.ninja/55
+REACT_APP_IS_TEST_ENVIRONMENT=0
+
+BROWSER_TESTS_UID=
+BROWSER_TESTS_PWD=
+BROWSER_TESTS_ENV_URL=http://localhost:3001

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,7 @@ yarn-error.log*
 screenshots
 report
 
-# don't store any .env files in version control
+# don't store these .env files in version control
 .env
 .env.development
-.env.test
 .env.production

--- a/src/domain/authentication/__tests__/__snapshots__/authService.test.js.snap
+++ b/src/domain/authentication/__tests__/__snapshots__/authService.test.js.snap
@@ -2,10 +2,14 @@
 
 exports[`authService fetchApiToken should call axios with the right arguments 1`] = `
 Array [
-  "https://tunnistamo.test.kuva.hel.ninja/api-tokens/",
+  "https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect/token",
   Object {
-    "baseURL": "https://tunnistamo.test.kuva.hel.ninja/",
-    "data": Object {},
+    "baseURL": "https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/",
+    "data": Object {
+      "audience": "kukkuu-api-test",
+      "grant_type": "urn:ietf:params:oauth:grant-type:uma-ticket",
+      "permission": "#access",
+    },
     "headers": Object {
       "Accept": "application/json",
       "Authorization": "bearer db237bc3-e197-43de-8c86-3feea4c5f886",

--- a/src/domain/authentication/authorizationService.ts
+++ b/src/domain/authentication/authorizationService.ts
@@ -72,10 +72,11 @@ export class AuthorizationService {
       const projects = ProjectList((data as any)?.projects).items;
       const role = projects.length > 0 ? 'admin' : 'none';
       const projectPermissions = getProjectPermissions(projects);
-
       projectService.setDefaultProjectId(projects);
       this.setPermissionStorage({ role, projects: projectPermissions });
-    } catch (e) {
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to fetch user role/permissions', error);
       this.setPermissionStorage({ role: 'none' });
     }
   }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -11,4 +11,4 @@ jest.mock('react-admin', () => ({
   ...jest.requireActual('react-admin'),
 }));
 
-dotenv.config({ path: '.env.example' });
+dotenv.config({ path: '.env.test' });


### PR DESCRIPTION
## Description

### feat: add silent token refreshing with Keycloak only

after this change the tokens will be refreshed automatically before the
refresh token expires even if the user does nothing

also:
 - set predictable environment variables for tests using .env.test to
   make tests run the same locally and in CI/CD pipeline

refs KK-1156

## Context

[KK-1156](https://helsinkisolutionoffice.atlassian.net/browse/KK-1156)

## How Has This Been Tested?

Logged in, left the browser running for over 5 mins, saw that network tab contained token fetching, tried to access resources in admin-UI, was successful → **silent refresh works** ✅

## Manual Testing Instructions for Reviewers

- Check out PR's branch locally
- Put this into `.env`
```
PORT=3001
BROWSER_TESTS_UID=
BROWSER_TESTS_PWD=
BROWSER_TESTS_ENV_URL=http://localhost:3001
REACT_APP_KUKKUU_API_OIDC_SCOPE=https://api.hel.fi/auth/kukkuu
REACT_APP_API_URI=https://kukkuu.api.test.hel.ninja/graphql
REACT_APP_SENTRY_DSN=https://c89ee3f57dc94ffd940d1df1a353b97f@sentry.hel.ninja/55
REACT_APP_OIDC_SERVER_TYPE=KEYCLOAK
REACT_APP_OIDC_RETURN_TYPE="code"
REACT_APP_OIDC_AUTHORITY=https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/
REACT_APP_OIDC_CLIENT_ID="kukkuu-admin-ui-test"
REACT_APP_OIDC_KUKKUU_API_CLIENT_ID="kukkuu-api-test"
REACT_APP_OIDC_SCOPE="openid profile email"
REACT_APP_OIDC_AUDIENCES=kukkuu-api-test
REACT_APP_API_URI=https://kukkuu.api.test.hel.ninja/graphql
REACT_APP_SENTRY_DSN=
REACT_APP_FEATURE_FLAG_EXTERNAL_TICKET_SYSTEM_SUPPORT=true
```
- `yarn` to install dependencies
- `yarn start`
- Log in to admin-UI with a user with credentials allowed to login
  - Add credentials using local Django admin if needed
- Once logged in do nothing for over 5 minutes (that should be the expiration time of Keycloak's access tokens in testing environment) and try doing something (You can keep the developer tools' network tab open to see that something should happen during your waiting)
  - Voila! You should not have been logged out and you should be able to still access resources

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1156]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ