### PR TITLE
(DRAFT) KK-1156 | Add active (i.e. based on user action) token refreshing with Keycloak

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,16 @@
+PORT=3001
+REACT_APP_OIDC_AUDIENCES=kukkuu-api-test
+REACT_APP_OIDC_AUTHORITY=https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/
+REACT_APP_OIDC_CLIENT_ID=kukkuu-admin-ui-test
+REACT_APP_OIDC_KUKKUU_API_CLIENT_ID=kukkuu-api-test
+REACT_APP_OIDC_RETURN_TYPE=code
+REACT_APP_OIDC_SCOPE="openid profile email"
+REACT_APP_OIDC_SERVER_TYPE=KEYCLOAK
+REACT_APP_KUKKUU_API_OIDC_SCOPE=https://api.hel.fi/auth/kukkuu
+REACT_APP_API_URI=https://kukkuu.api.test.hel.ninja/graphql
+REACT_APP_SENTRY_DSN=https://c89ee3f57dc94ffd940d1df1a353b97f@sentry.hel.ninja/55
+REACT_APP_IS_TEST_ENVIRONMENT=0
+
+BROWSER_TESTS_UID=
+BROWSER_TESTS_PWD=
+BROWSER_TESTS_ENV_URL=http://localhost:3001

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,7 @@ yarn-error.log*
 screenshots
 report
 
-# don't store any .env files in version control
+# don't store these .env files in version control
 .env
 .env.development
-.env.test
 .env.production

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-testcafe": "^0.2.1",
     "graphql": "^16.8.1",
     "history": "^5.3.0",
+    "jwt-decode": "^4.0.0",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.43",
     "oidc-client-ts": "^3.0.1",

--- a/src/domain/authentication/__tests__/__snapshots__/authService.test.js.snap
+++ b/src/domain/authentication/__tests__/__snapshots__/authService.test.js.snap
@@ -2,10 +2,14 @@
 
 exports[`authService fetchApiToken should call axios with the right arguments 1`] = `
 Array [
-  "https://tunnistamo.test.kuva.hel.ninja/api-tokens/",
+  "https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/protocol/openid-connect/token",
   Object {
-    "baseURL": "https://tunnistamo.test.kuva.hel.ninja/",
-    "data": Object {},
+    "baseURL": "https://tunnistus.test.hel.ninja/auth/realms/helsinki-tunnistus/",
+    "data": Object {
+      "audience": "kukkuu-api-test",
+      "grant_type": "urn:ietf:params:oauth:grant-type:uma-ticket",
+      "permission": "#access",
+    },
     "headers": Object {
       "Accept": "application/json",
       "Authorization": "bearer db237bc3-e197-43de-8c86-3feea4c5f886",

--- a/src/domain/authentication/__tests__/authService.test.js
+++ b/src/domain/authentication/__tests__/authService.test.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import authService, { API_TOKEN, REFRESH_TOKEN } from '../authService';
 import authorizationService from '../authorizationService';
 import AppConfig from '../../application/AppConfig';
-import dataProvider from '../../../api/dataProvider';
+import { dataProviderBeforeWrappingWithProxy } from '../../../api/dataProvider';
 
 jest.mock('axios');
 
@@ -16,26 +16,28 @@ describe('authService', () => {
   const userManager = authService.userManager;
 
   beforeEach(() => {
-    jest.spyOn(dataProvider, 'getMyAdminProfile').mockResolvedValue({
-      data: {
-        id: btoa('AdminNode:123'),
-        projects: {
-          edges: [
-            {
-              node: {
-                id: testProjectId,
-                year: 2023,
-                name: 'test project 2023',
-                myPermissions: {
-                  publish: true,
-                  manageEventGroups: true,
+    jest
+      .spyOn(dataProviderBeforeWrappingWithProxy, 'getMyAdminProfile')
+      .mockResolvedValue({
+        data: {
+          id: btoa('AdminNode:123'),
+          projects: {
+            edges: [
+              {
+                node: {
+                  id: testProjectId,
+                  year: 2023,
+                  name: 'test project 2023',
+                  myPermissions: {
+                    publish: true,
+                    manageEventGroups: true,
+                  },
                 },
               },
-            },
-          ],
+            ],
+          },
         },
-      },
-    });
+      });
   });
 
   afterEach(() => {

--- a/src/domain/authentication/__tests__/authorizationService.test.js
+++ b/src/domain/authentication/__tests__/authorizationService.test.js
@@ -1,4 +1,4 @@
-import dataProvider from '../../../api/dataProvider';
+import { dataProviderBeforeWrappingWithProxy } from '../../../api/dataProvider';
 import projectService from '../../projects/projectService';
 import authorizationService, { PERMISSIONS } from '../authorizationService';
 
@@ -16,7 +16,7 @@ describe('authorizationService', () => {
 
   beforeEach(() => {
     dataProviderSpy = jest
-      .spyOn(dataProvider, 'getMyAdminProfile')
+      .spyOn(dataProviderBeforeWrappingWithProxy, 'getMyAdminProfile')
       .mockResolvedValue({
         data: {
           projects: {

--- a/src/domain/authentication/authProvider.ts
+++ b/src/domain/authentication/authProvider.ts
@@ -1,7 +1,9 @@
 import type { AuthProvider } from 'ra-core';
+import { addRefreshAuthToAuthProvider } from 'react-admin';
 
 import authService from './authService';
 import authorizationService from './authorizationService';
+import { refreshAuth } from './refreshAuth';
 
 export type Permissions = {
   role: null | 'admin' | 'none';
@@ -67,4 +69,9 @@ const authProvider: AuthProvider = {
   },
 };
 
-export default authProvider;
+const authProviderWithRefreshAuth = addRefreshAuthToAuthProvider(
+  authProvider,
+  refreshAuth
+);
+
+export default authProviderWithRefreshAuth;

--- a/src/domain/authentication/authorizationService.ts
+++ b/src/domain/authentication/authorizationService.ts
@@ -72,10 +72,11 @@ export class AuthorizationService {
       const projects = ProjectList((data as any)?.projects).items;
       const role = projects.length > 0 ? 'admin' : 'none';
       const projectPermissions = getProjectPermissions(projects);
-
       projectService.setDefaultProjectId(projects);
       this.setPermissionStorage({ role, projects: projectPermissions });
-    } catch (e) {
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to fetch user role/permissions', error);
       this.setPermissionStorage({ role: 'none' });
     }
   }

--- a/src/domain/authentication/isUnexpiredToken.ts
+++ b/src/domain/authentication/isUnexpiredToken.ts
@@ -1,0 +1,23 @@
+import type { JwtPayload } from 'jwt-decode';
+import { InvalidTokenError, jwtDecode } from 'jwt-decode';
+
+const isUnexpiredToken = (token?: string | null): boolean => {
+  if (!token) {
+    return false;
+  }
+
+  try {
+    const decodedToken = jwtDecode<JwtPayload>(token);
+    const secondsSinceEpoch = Date.now() / 1000;
+    return (
+      decodedToken.exp !== undefined && decodedToken.exp >= secondsSinceEpoch
+    );
+  } catch (error) {
+    if (error instanceof InvalidTokenError) {
+      return false;
+    }
+    throw error;
+  }
+};
+
+export default isUnexpiredToken;

--- a/src/domain/authentication/refreshAuth.ts
+++ b/src/domain/authentication/refreshAuth.ts
@@ -1,0 +1,10 @@
+import authService from './authService';
+import isUnexpiredToken from './isUnexpiredToken';
+
+export const refreshAuth = async (): Promise<void> => {
+  const accessToken = authService.getToken();
+  const refreshToken = authService.getRefreshToken();
+  if (!isUnexpiredToken(accessToken) && isUnexpiredToken(refreshToken)) {
+    await authService.renewToken();
+  }
+};

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -11,4 +11,4 @@ jest.mock('react-admin', () => ({
   ...jest.requireActual('react-admin'),
 }));
 
-dotenv.config({ path: '.env.example' });
+dotenv.config({ path: '.env.test' });


### PR DESCRIPTION
## Description

**NOTE**:
- Based on the PR #270 [testing](https://github.com/City-of-Helsinki/kukkuu-admin/pull/270#issuecomment-2160426484) this does **not** seem to be **working** correctly at the moment. But split here if needed for some reason later (e.g. if someone comes up with a use case for this functionality and fixes this).

### feat: add active (on user action) token refreshing with Keycloak only

means that when the user actively uses the application the tokens will get checked and refreshed if needed

refs KK-1156

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-1156](https://helsinkisolutionoffice.atlassian.net/browse/KK-1156)
Split from https://github.com/City-of-Helsinki/kukkuu-admin/pull/270

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1156]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ