### PR TITLE
KK-1371 | Miscellaneous fixes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -79,5 +79,14 @@ module.exports = {
     'no-plusplus': 'error',
     'no-undef': 'warn',
     'object-curly-spacing': ['warn', 'always'],
+    '@vitest/expect-expect': [
+      'error',
+      {
+        assertFunctionNames: [
+          'expect',
+          'checkErrors', // some tests use only this function to check errors
+        ],
+      },
+    ],
   },
 };

--- a/src/common/__tests__/utils.test.js
+++ b/src/common/__tests__/utils.test.js
@@ -32,7 +32,7 @@ describe('common utils', () => {
       vi.clearAllMocks();
     });
 
-    // eslint-disable-next-line max-len, @vitest/expect-expect
+    // eslint-disable-next-line max-len
     it('should label all languages with an error when the field in question is missing in the Finnish language version', () => {
       const errors = requireFinnishFields({}, ['name', errorMessage]);
 
@@ -56,7 +56,6 @@ describe('common utils', () => {
       expect(errors.translations.EN).toEqual({});
     });
 
-    // eslint-disable-next-line @vitest/expect-expect
     it('should support multiple fields', () => {
       const errorMessage2 = 'error 2';
       const errors = requireFinnishFields(

--- a/src/domain/authentication/__tests__/idleProvider.test.jsx
+++ b/src/domain/authentication/__tests__/idleProvider.test.jsx
@@ -43,9 +43,7 @@ test.each([
 
     vi.advanceTimersByTime(advancedTimeMs);
 
-    React.act(() => {
-      fireEvent.focus(document);
-    });
+    fireEvent.focus(document);
 
     if (logoutExpected) {
       expect(logoutSpy).toHaveBeenCalled();

--- a/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
+++ b/src/domain/eventGroups/detail/__tests__/EventGroupsDetailActions.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as ReactAdmin from 'react-admin';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material';
 import { createTheme } from '@mui/material/styles/';
 
@@ -55,11 +55,11 @@ describe('<EventGroupsDetailActions />', () => {
     });
     getWrapper();
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('link', { name: 'eventGroups.actions.addEvent.do' })
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('link', {
+        name: 'eventGroups.actions.addEvent.do',
+      })
+    ).toBeInTheDocument();
   });
 
   it('should show an edit button', () => {

--- a/src/domain/events/detail/__tests__/EventReadyToggle.test.jsx
+++ b/src/domain/events/detail/__tests__/EventReadyToggle.test.jsx
@@ -59,9 +59,7 @@ describe('<EventReadyToggle />', () => {
 
     expect(getInput(wrapper)).toHaveProperty('checked', false);
 
-    React.act(() => {
-      fireEvent.click(getInput(wrapper));
-    });
+    fireEvent.click(getInput(wrapper));
 
     await waitFor(() => {
       expect(getInput(wrapper)).toHaveProperty('checked', true);
@@ -71,16 +69,14 @@ describe('<EventReadyToggle />', () => {
   it('should use the result it receives in the response as soon as it is available', async () => {
     const wrapper = getWrapper({}, false);
 
-    React.act(() => {
-      fireEvent.click(getInput(wrapper));
-    });
+    fireEvent.click(getInput(wrapper));
 
     await waitFor(() => {
       expect(getInput(wrapper)).toHaveProperty('checked', true);
     });
 
-    await waitFor(() =>
-      expect(getInput(wrapper)).toHaveProperty('checked', false)
-    );
+    await waitFor(() => {
+      expect(getInput(wrapper)).toHaveProperty('checked', false);
+    });
   });
 });

--- a/src/domain/events/detail/__tests__/EventShowActions.test.jsx
+++ b/src/domain/events/detail/__tests__/EventShowActions.test.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import * as ReactAdmin from 'react-admin';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material';
 import { createTheme } from '@mui/material/styles';
 
 import EventShowActions from '../EventShowActions';
-import { permission } from 'process';
 
 const defaultContext = {
   data: {
@@ -39,11 +38,9 @@ describe('<EventShowActions />', () => {
 
     getWrapper(context);
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('link', { name: 'ra.action.edit' })
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole('link', { name: 'ra.action.edit' })
+    ).toBeInTheDocument();
   });
 
   describe('when the user has publish permissions', () => {

--- a/src/domain/profile/__tests__/ProfileProjectDropdown.test.jsx
+++ b/src/domain/profile/__tests__/ProfileProjectDropdown.test.jsx
@@ -56,10 +56,8 @@ describe('<ProfileProjectDropdown />', () => {
     });
 
     const { container } = getWrapper();
-    await React.act(async () => {
-      await waitFor(() => {
-        expect(container.childNodes.length).toEqual(0);
-      });
+    await waitFor(() => {
+      expect(container.childNodes.length).toEqual(0);
     });
   });
 
@@ -112,18 +110,14 @@ describe('<ProfileProjectDropdown />', () => {
     // Expect to see menu toggle button
     expect(button).toBeInTheDocument();
 
-    React.act(() => {
-      fireEvent.click(button);
-    });
+    fireEvent.click(button);
 
     const menuItems = screen.getAllByRole('menuitem');
 
     // After clicking menu toggle expect to see menu items
     expect(menuItems.length).toEqual(2);
 
-    React.act(() => {
-      fireEvent.click(menuItems[1]);
-    });
+    fireEvent.click(menuItems[1]);
 
     // After selecting an item
     // Expect projectId to be set

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference types="react-scripts" />
+import 'react-scripts';


### PR DESCRIPTION
## Description

Miscellaneous fixes:
- Use import instead of /// in react-app-env.d.ts to fix linting
- Remove unneeded React.act wrappings, no extra warnings, tests pass
- Simplify tests by using await screen.findByRole
- Fix linting @vitest/expect-expect by adding checkErrors to it

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[KK-1371](https://helsinkisolutionoffice.atlassian.net/browse/KK-1371)

## How Has This Been Tested?

Ran "yarn lint", "yarn typecheck" and "yarn test" locally with this branch and they all passed.

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1371]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ