### PR TITLE
fix(config): admin ui url

### DIFF
--- a/browser-tests/utils/jwt/jwt.ts
+++ b/browser-tests/utils/jwt/jwt.ts
@@ -34,7 +34,7 @@ export function getEpochTimeframeForTestJWt(
 export function generateTestJwt({
   user,
   prefix,
-  issuer = 'https://kukkuu-admin-ui.test.hel.ninja',
+  issuer = 'https://kukkuu-admin.test.hel.ninja',
   audience = BrowserTestJWTConfig.oidcApiClientId,
   type = 'Bearer',
   authTime = new Date(),


### PR DESCRIPTION
Fix the Kukkuu Admin UI URL

Instead of
- https://kukkuu-admin-ui.test.hel.ninja/
- https://kukkuu-admin-ui.stage.hel.ninja/

the URLs for the Admin UI are:
- https://kukkuu-admin.test.hel.ninja/
- https://kukkuu-admin.stage.hel.ninja/
