### PR TITLE
fix(docker): dev compose uses polling to detect code changes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,9 @@ export default ({ mode }: any) => {
     },
     plugins: [react(), eslint(), viteTsconfigPaths()],
     server: {
+      watch: {
+        usePolling: Boolean(process.env.NODE_ENV === 'development'),
+      },
       open: true, // automatically open the app in the browser
       port: parseInt(process.env.PORT ?? '3001'),
     },


### PR DESCRIPTION
KK-1367 KK-1392.

For server reload on code changes, enable server watch with polling when `NODE_ENV` is set to `development`.

See more from Vite: https://vite.dev/config/server-options#server-watch.
