### PR TITLE
KK-1367 | Use polling in docker development to enable hot reload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,13 @@ FROM appbase AS development
 ARG NODE_ENV=development
 ENV NODE_ENV $NODE_ENV
 
+# Enable hot reload by default by polling for file changes.
+#
+# NOTE: Can be disabled by setting CHOKIDAR_USEPOLLING=false in file `.env`
+#       if hot reload works on your system without polling to save CPU time.
+ARG CHOKIDAR_USEPOLLING=true
+ENV CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING}
+
 # copy in our source code last, as it changes the most
 COPY --chown=default:root . .
 


### PR DESCRIPTION
## Description

Enable polling only for Docker development as an alternative to PR #299.

<!-- Describe your changes in detail -->

## Context

[KK-1367](https://helsinkisolutionoffice.atlassian.net/browse/KK-1367)

## How Has This Been Tested?

Ran "docker compose up --build", opened the UI in web browser, and changed LoginPage.tsx's title text a few times and avot, the text changed in the browser with some delay.

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[KK-1367]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ