### PR TITLE
Fix validation of the DateTimeTextField when it's disabled.

### DIFF
--- a/src/common/components/dateTimeTextField/DateTimeTextField.tsx
+++ b/src/common/components/dateTimeTextField/DateTimeTextField.tsx
@@ -82,19 +82,25 @@ const BoundedTextField = (props: BoundedTextFieldProps) => {
   );
 };
 
-const validateDate: Validator = (value: string) =>
-  momentValidationDateFormats.some((format) =>
+const validateDate: Validator = (value?: string) => {
+  if (value === undefined) return undefined;
+
+  return momentValidationDateFormats.some((format) =>
     moment(value, format, true).isValid()
   )
     ? undefined
     : 'occurrences.fields.time.fields.date.errorMessage';
+};
 
-const validateTime: Validator = (value: string) =>
-  momentValidationTimeFormats.some((format) =>
+const validateTime: Validator = (value?: string) => {
+  if (value === undefined) return undefined;
+
+  return momentValidationTimeFormats.some((format) =>
     moment(value, format, true).isValid()
   )
     ? undefined
     : 'occurrences.fields.time.fields.time.errorMessage';
+};
 
 const DateTimeTextInput = ({
   variant,

--- a/src/domain/occurrences/OccurrenceShow.tsx
+++ b/src/domain/occurrences/OccurrenceShow.tsx
@@ -161,10 +161,8 @@ const OccurrenceShow = () => {
               )}
               label="events.fields.language.label"
             />
-            <FunctionField
-              render={OccurrenceAttendedField}
-              label="enrolments.fields.attended.label"
-            />
+            {/* @ts-ignore - label is magically handled by material-ui */}
+            <OccurrenceAttendedField label="enrolments.fields.attended.label" />
           </Datagrid>
         </ArrayField>
       </SimpleShowLayout>

--- a/src/domain/occurrences/api/OccurrenceApi.ts
+++ b/src/domain/occurrences/api/OccurrenceApi.ts
@@ -46,8 +46,10 @@ const getOccurrence: MethodHandler = async (params: MethodHandlerParams) => {
 };
 
 // Combine two fields into one:
-const normalizeTime = (date: string, time: string) => {
+const normalizeTime = (date?: string, time?: string) => {
   let datetime;
+
+  if (date === undefined || time === undefined) return undefined;
 
   for (const format of Config.momentValidationDateTimeFormats) {
     datetime = moment.tz(`${date} ${time}`, format, true, 'Europe/Helsinki');


### PR DESCRIPTION
Fix validation of the DateTimeTextField when it's disabled.

KK-1423.

Occurrence API normalizeTime -function needs to be able to handle
undefined date and time too. This happens e.g. when the fields are
disabled. The normalization should not be done when the denomarlized
value is not set.

----

Fix a hook usage error.

KK-1423.

When a list of occurrence enrolments was rendered, the console went
crazy by reporting an issue in hook usage. This was because a React
component was used in FunctionField render-property and the hooks were
no longer in root level.

By removing the Function field and rendering the OccurrenceAttendedField
directly, the feature still works and the hook warnings are no longer
raised. A catch is, that the field does not have a label property for
the Material UI grid, but the label is still read properly by the
Material UI. Only the TS compiler reports that there is no field called
label, so that needs to be ignored (as in EventShow PublishedField too).