### PR TITLE
fix: set max size to 1MB for image upload

### DIFF
--- a/src/common/components/imageField/ImageUploadField.tsx
+++ b/src/common/components/imageField/ImageUploadField.tsx
@@ -51,13 +51,20 @@ const MAX_SUPPORTED_FILE_SIZE_BYTES = 1_000_000; // 1MB
  */
 const ImageUploadField = ({
   name,
-  edit,
+  edit: isEditViewActive,
   image,
   source,
   helperText,
   maxSize = MAX_SUPPORTED_FILE_SIZE_BYTES,
 }: ImageUploadFieldProps) => {
   const translate = useTranslate();
+
+  // State to track if the image is persisted in the backend
+  // This is used to determine if the image preview should be formatted
+  // or if it should show the newly uploaded image.
+  // If the form is in edit mode, we assume the image is already persisted.
+  const [isImagePersisted, setIsImagePersisted] =
+    React.useState(isEditViewActive);
 
   // Enforce the hard limit on the maxSize prop
   if (maxSize > MAX_SUPPORTED_FILE_SIZE_BYTES) {
@@ -68,10 +75,14 @@ const ImageUploadField = ({
     );
   }
 
+  // The preview immage needs different configuration when handling a newly uploaded image
+  // and image that is already in the backend.
+  const onChangeHandler = () => setIsImagePersisted(false);
+
   return (
     <ImageInput
       name={name ?? source}
-      format={edit ? formatImage : undefined}
+      format={isImagePersisted ? formatImage : undefined}
       source={image}
       label={'events.fields.image.label'}
       accept="image/*"
@@ -83,8 +94,9 @@ const ImageUploadField = ({
       }
       helperText={helperText}
       maxSize={maxSize}
+      onChange={onChangeHandler}
     >
-      <ImageField source={edit ? source : 'src'} title="title" />
+      <ImageField source={isImagePersisted ? source : 'src'} title="title" />
     </ImageInput>
   );
 };

--- a/src/common/translation/en.json
+++ b/src/common/translation/en.json
@@ -93,7 +93,10 @@
       },
       "image": {
         "helperText": "",
-        "label": "Image"
+        "label": "Image",
+        "error": {
+          "genericFileRejected": "Could not upload the file. Check the file size (max %{maxSize} KB) any type."
+        }
       },
       "imageAltText": {
         "helperText": "",

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -92,7 +92,7 @@
         "label": "ID"
       },
       "image": {
-        "helperText": "Kuvan tulee olla vähintään 1400px leveä ja tärkein sisältö mielellään kuvan yläosassa, jotta tämä toimisi tapahtumasivun taustakuvana.",
+        "helperText": "Kuvan tulee olla vähintään 1400px leveä ja tärkein sisältö mielellään kuvan yläosassa, jotta tämä toimisi tapahtumasivun taustakuvana. Maksimi tiedostokoko on 1MB.",
         "label": "Kuva"
       },
       "imageAltText": {

--- a/src/common/translation/fi.json
+++ b/src/common/translation/fi.json
@@ -93,7 +93,10 @@
       },
       "image": {
         "helperText": "Kuvan tulee olla vähintään 1400px leveä ja tärkein sisältö mielellään kuvan yläosassa, jotta tämä toimisi tapahtumasivun taustakuvana. Maksimi tiedostokoko on 1MB.",
-        "label": "Kuva"
+        "label": "Kuva",
+        "error": {
+          "genericFileRejected": "Tiedostoa ei voitu ladata. Tarkista tiedoston koko (enint. %{maxSize} KB) ja tyyppi."
+        }
       },
       "imageAltText": {
         "helperText": "Lisää kuvan alt-tekstiin kuvaajan nimi ja kuvaus siitä mitä kuva esittää",

--- a/src/common/translation/sv.json
+++ b/src/common/translation/sv.json
@@ -93,7 +93,10 @@
       },
       "image": {
         "helperText": "",
-        "label": "Image"
+        "label": "Image",
+        "error": {
+          "genericFileRejected": "Could not upload the file. Check the file size (max %{maxSize} KB) any type."
+        }
       },
       "imageAltText": {
         "helperText": "",


### PR DESCRIPTION
KK-1426.

The image upload process ended in "cannot pickle '_io.BufferedRandom' object" error if a too large image was uploaded. The file upload size is set 1MB in Nginx by default (source:
https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) and to 2,5MB in Django (source:
https://docs.djangoproject.com/en/5.2/ref/settings/#file-upload-max-memory-size and
https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-DATA_UPLOAD_MAX_MEMORY_SIZE). The default for React-Admin's ImageInput was `Infinity` (source: https://marmelab.com/react-admin/ImageInput.html), so it was more than what Nginx and Django could handle. The max size that we want to support in our Web app is 1MB, because larger than that would be bad for user experience (because of  pages' total sizes).

Also a new state is added to the component, so we can track whether the image is being changed and but is not yet uploaded to the backend storage. This affects to how the preview of the image is rendered. The new state fixes the situation, when a user is changing the image in edit view.

<img width="690" alt="image" src="https://github.com/user-attachments/assets/48fb3543-8f1d-49b0-833f-0cc7ee5706bd" />
