### PR TITLE
fix: enforce frozen lockfile by default

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.frozen-lockfile true


### PR DESCRIPTION
Discussed with @tuomas777 and decided to default to frozen lockfile to prevent unintentional dependency upgrades. In future, to upgrade a package please refer to dependabot or yarn upgrade <package_name> command.